### PR TITLE
[refactor/#16] 프로필 저장 로직 수정

### DIFF
--- a/src/main/kotlin/codel/auth/TokenProvider.kt
+++ b/src/main/kotlin/codel/auth/TokenProvider.kt
@@ -2,6 +2,7 @@ package codel.auth
 
 import codel.auth.exception.AuthException
 import codel.member.domain.Member
+import codel.member.domain.OauthType
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
@@ -10,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import java.security.Key
-import java.util.Date
+import java.util.*
 
 @Component
 class TokenProvider(
@@ -67,5 +68,7 @@ class TokenProvider(
         }
     }
 
-    fun extractMemberId(token: String): Long = getPayload(token)[MEMBER_ID_CLAIM_KEY].toString().toLong()
+    fun extractOauthId(token: String): String = getPayload(token)[SOCIAL_LOGIN_ID_CLAIM_KEY].toString()
+
+    fun extractOauthType(token: String): OauthType = OauthType.valueOf(getPayload(token)[OAUTH_TYPE].toString())
 }

--- a/src/main/kotlin/codel/auth/business/AuthService.kt
+++ b/src/main/kotlin/codel/auth/business/AuthService.kt
@@ -1,17 +1,17 @@
 package codel.auth.business
 
 import codel.auth.TokenProvider
-import codel.member.domain.MemberRepository
+import codel.member.business.MemberService
 import codel.member.presentation.request.MemberLoginRequest
 import org.springframework.stereotype.Service
 
 @Service
 class AuthService(
     val tokenProvider: TokenProvider,
-    val memberRepository: MemberRepository,
+    val memberService: MemberService,
 ) {
     fun provideToken(request: MemberLoginRequest): String {
-        val member = memberRepository.findMember(request.oauthType, request.oauthId)
+        val member = memberService.findMember(request.oauthType, request.oauthId)
         return tokenProvider.provide(member)
     }
 }

--- a/src/main/kotlin/codel/config/WebMvcConfig.kt
+++ b/src/main/kotlin/codel/config/WebMvcConfig.kt
@@ -1,0 +1,15 @@
+package codel.config
+
+import codel.config.argumentresolver.MemberArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val memberArgumentResolver: MemberArgumentResolver,
+) : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(memberArgumentResolver)
+    }
+}

--- a/src/main/kotlin/codel/config/argumentresolver/LoginMember.kt
+++ b/src/main/kotlin/codel/config/argumentresolver/LoginMember.kt
@@ -1,0 +1,5 @@
+package codel.config.argumentresolver
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LoginMember

--- a/src/main/kotlin/codel/config/argumentresolver/MemberArgumentResolver.kt
+++ b/src/main/kotlin/codel/config/argumentresolver/MemberArgumentResolver.kt
@@ -1,20 +1,18 @@
 package codel.config.argumentresolver
 
-import codel.auth.TokenProvider
-import codel.auth.exception.AuthException
 import codel.member.business.MemberService
 import codel.member.domain.Member
+import codel.member.domain.OauthType
 import org.springframework.core.MethodParameter
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.context.request.RequestAttributes
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 
 @Component
 class MemberArgumentResolver(
     private val memberService: MemberService,
-    private val tokenProvider: TokenProvider,
 ) : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean =
         parameter.hasParameterAnnotation(LoginMember::class.java) &&
@@ -26,18 +24,14 @@ class MemberArgumentResolver(
         webRequest: NativeWebRequest,
         binderFactory: org.springframework.web.bind.support.WebDataBinderFactory?,
     ): Any? {
-        val token = resolveToken(webRequest)
-        val memberId = tokenProvider.extractMemberId(token)
+        val oauthId =
+            webRequest.getAttribute("oauthId", RequestAttributes.SCOPE_REQUEST) as? String
+                ?: throw IllegalArgumentException("oauthId가 요청이 없습니다.")
 
-        return memberService.findMember(memberId)
-    }
+        val oauthType =
+            webRequest.getAttribute("oauthType", RequestAttributes.SCOPE_REQUEST) as? OauthType
+                ?: throw IllegalArgumentException("oauthType이 요청이 없습니다.")
 
-    private fun resolveToken(webRequest: NativeWebRequest): String {
-        val bearer = webRequest.getHeader("Authorization")
-        return if (bearer != null && bearer.startsWith("Bearer ")) {
-            bearer.substring(7)
-        } else {
-            throw AuthException(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.")
-        }
+        return memberService.findMember(oauthType, oauthId)
     }
 }

--- a/src/main/kotlin/codel/config/argumentresolver/MemberArgumentResolver.kt
+++ b/src/main/kotlin/codel/config/argumentresolver/MemberArgumentResolver.kt
@@ -1,0 +1,43 @@
+package codel.config.argumentresolver
+
+import codel.auth.TokenProvider
+import codel.auth.exception.AuthException
+import codel.member.business.MemberService
+import codel.member.domain.Member
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class MemberArgumentResolver(
+    private val memberService: MemberService,
+    private val tokenProvider: TokenProvider,
+) : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(LoginMember::class.java) &&
+            parameter.parameterType == Member::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: org.springframework.web.bind.support.WebDataBinderFactory?,
+    ): Any? {
+        val token = resolveToken(webRequest)
+        val memberId = tokenProvider.extractMemberId(token)
+
+        return memberService.findMember(memberId)
+    }
+
+    private fun resolveToken(webRequest: NativeWebRequest): String {
+        val bearer = webRequest.getHeader("Authorization")
+        return if (bearer != null && bearer.startsWith("Bearer ")) {
+            bearer.substring(7)
+        } else {
+            throw AuthException(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/codel/config/filter/JwtAuthFilter.kt
+++ b/src/main/kotlin/codel/config/filter/JwtAuthFilter.kt
@@ -40,8 +40,10 @@ class JwtAuthFilter(
             response.writer.write("""{"message": "인증되지 않은 사용자입니다."}""")
             return
         }
-        val memberId = tokenProvider.extractMemberId(token)
-        request.setAttribute("memberId", memberId)
+        val oauthId = tokenProvider.extractOauthId(token)
+        val oauthType = tokenProvider.extractOauthType(token)
+        request.setAttribute("oauthId", oauthId)
+        request.setAttribute("oauthType", oauthType)
 
         filterChain.doFilter(request, response)
     }

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -4,6 +4,7 @@ import codel.member.domain.CodeImage
 import codel.member.domain.ImageUploader
 import codel.member.domain.Member
 import codel.member.domain.MemberRepository
+import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
 import codel.member.domain.Profile
 import codel.member.presentation.request.CodeImageSavedRequest
@@ -29,7 +30,11 @@ class MemberService(
         return MemberLoginResponse(loginMember.memberStatus)
     }
 
-    fun saveProfile(request: ProfileSavedRequest) {
+    @Transactional
+    fun saveProfile(
+        member: Member,
+        request: ProfileSavedRequest,
+    ) {
         val profile =
             Profile(
                 codeName = request.codeName,
@@ -44,7 +49,9 @@ class MemberService(
                 mbti = request.mbti,
                 introduce = request.introduce,
             )
-        memberRepository.saveProfile(profile)
+
+        memberRepository.saveProfile(member, profile)
+        memberRepository.changeMemberStatus(member, MemberStatus.CODE_SURVEY)
     }
 
     fun findMember(

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -1,10 +1,10 @@
 package codel.member.business
 
 import codel.member.domain.CodeImage
+import codel.member.domain.ImageUploader
 import codel.member.domain.Member
 import codel.member.domain.MemberRepository
 import codel.member.domain.Profile
-import codel.member.domain.S3Uploader
 import codel.member.presentation.request.CodeImageSavedRequest
 import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val s3Uploader: S3Uploader,
+    private val imageUploader: ImageUploader,
 ) {
     fun loginMember(request: MemberLoginRequest): MemberLoginResponse {
         val member =
@@ -47,12 +47,19 @@ class MemberService(
     }
 
     @Transactional
-    fun saveCodeImage(request: CodeImageSavedRequest) {
-        val imageFiles = request.imageFiles
-        val codeImages = CodeImage(imageFiles.map { file -> s3Uploader.uploadFile(file) })
+    fun saveCodeImage(
+        member: Member,
+        request: CodeImageSavedRequest,
+    ) {
+        val codeImage = uploadFile(request)
 
-        memberRepository.saveImagePath(codeImages)
+        memberRepository.saveImagePath(member, codeImage)
 
         // memberStatus 수정
+    }
+
+    private fun uploadFile(request: CodeImageSavedRequest): CodeImage {
+        val imageFiles = request.imageFiles
+        return CodeImage(imageFiles.map { file -> imageUploader.uploadFile(file) })
     }
 }

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -4,6 +4,7 @@ import codel.member.domain.CodeImage
 import codel.member.domain.ImageUploader
 import codel.member.domain.Member
 import codel.member.domain.MemberRepository
+import codel.member.domain.OauthType
 import codel.member.domain.Profile
 import codel.member.presentation.request.CodeImageSavedRequest
 import codel.member.presentation.request.MemberLoginRequest
@@ -45,6 +46,11 @@ class MemberService(
             )
         memberRepository.saveProfile(profile)
     }
+
+    fun findMember(
+        oauthType: OauthType,
+        oauthId: String,
+    ): Member = memberRepository.findMember(oauthType, oauthId)
 
     @Transactional
     fun saveCodeImage(

--- a/src/main/kotlin/codel/member/domain/ImageUploader.kt
+++ b/src/main/kotlin/codel/member/domain/ImageUploader.kt
@@ -1,0 +1,7 @@
+package codel.member.domain
+
+import org.springframework.web.multipart.MultipartFile
+
+interface ImageUploader {
+    fun uploadFile(file: MultipartFile): String
+}

--- a/src/main/kotlin/codel/member/domain/Member.kt
+++ b/src/main/kotlin/codel/member/domain/Member.kt
@@ -5,5 +5,15 @@ class Member(
     val profile: Profile? = null,
     val oauthType: OauthType,
     val oauthId: String,
+    private var codeImage: CodeImage? = null,
+    private var faceImage: FaceImage? = null,
     val memberStatus: MemberStatus = MemberStatus.SIGNUP,
-)
+) {
+    fun saveCodeImage(codeImage: CodeImage) {
+        this.codeImage = codeImage
+    }
+
+    fun saveFaceImage(faceImage: FaceImage) {
+        this.faceImage = faceImage
+    }
+}

--- a/src/main/kotlin/codel/member/domain/MemberRepository.kt
+++ b/src/main/kotlin/codel/member/domain/MemberRepository.kt
@@ -33,6 +33,12 @@ class MemberRepository(
         profileJpaRepository.save(ProfileEntity.toEntity(profile))
     }
 
-    fun saveImagePath(codeImage: CodeImage) {
+    fun saveImagePath(
+        member: Member,
+        codeImage: CodeImage,
+    ) {
+        member.saveCodeImage(codeImage)
+
+        val memberEntity = MemberEntity.toEntity(member)
     }
 }

--- a/src/main/kotlin/codel/member/domain/MemberRepository.kt
+++ b/src/main/kotlin/codel/member/domain/MemberRepository.kt
@@ -5,6 +5,7 @@ import codel.member.infrastructure.ProfileJpaRepository
 import codel.member.infrastructure.entity.MemberEntity
 import codel.member.infrastructure.entity.ProfileEntity
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
 @Component
@@ -29,8 +30,30 @@ class MemberRepository(
         return memberEntity.toDomain()
     }
 
-    fun saveProfile(profile: Profile) {
-        profileJpaRepository.save(ProfileEntity.toEntity(profile))
+    fun saveProfile(
+        member: Member,
+        profile: Profile,
+    ) {
+        val memberEntity = findMemberEntity(member)
+        val profileEntity = ProfileEntity.toEntity(profile)
+
+        profileJpaRepository.save(profileEntity)
+        memberEntity.saveProfileEntity(profileEntity)
+    }
+
+    fun changeMemberStatus(
+        member: Member,
+        status: MemberStatus,
+    ) {
+        val memberEntity = findMemberEntity(member)
+
+        memberEntity.changeMemberStatus(status)
+    }
+
+    private fun findMemberEntity(member: Member): MemberEntity {
+        val memberId = member.id ?: throw IllegalArgumentException("member id가 비어있습니다.")
+
+        return memberJpaRepository.findByIdOrNull(memberId) ?: throw IllegalArgumentException("멤버가 존재하지 않습니다.")
     }
 
     fun saveImagePath(

--- a/src/main/kotlin/codel/member/infrastructure/S3Uploader.kt
+++ b/src/main/kotlin/codel/member/infrastructure/S3Uploader.kt
@@ -1,5 +1,6 @@
-package codel.member.domain
+package codel.member.infrastructure
 
+import codel.member.domain.ImageUploader
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
@@ -12,8 +13,8 @@ import java.util.*
 class S3Uploader(
     private val s3Client: S3Client,
     @Value("\${cloud.aws.s3.bucket}") private val bucket: String,
-) {
-    fun uploadFile(file: MultipartFile): String {
+) : ImageUploader {
+    override fun uploadFile(file: MultipartFile): String {
         val fileName = "images/${UUID.randomUUID()}-${file.originalFilename}"
 
         val putObjectRequest =

--- a/src/main/kotlin/codel/member/infrastructure/entity/MemberEntity.kt
+++ b/src/main/kotlin/codel/member/infrastructure/entity/MemberEntity.kt
@@ -5,7 +5,13 @@ package codel.member.infrastructure.entity
 import codel.member.domain.Member
 import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
-import jakarta.persistence.*
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
 @Table(
@@ -35,8 +41,17 @@ class MemberEntity(
     fun toDomain(): Member =
         Member(
             id = this.id,
+            profile = this.profileEntity?.toDomain(),
             oauthType = this.oauthType,
             oauthId = this.oauthId,
             memberStatus = this.memberStatus,
         )
+
+    fun saveProfileEntity(profileEntity: ProfileEntity) {
+        this.profileEntity = profileEntity
+    }
+
+    fun changeMemberStatus(status: MemberStatus) {
+        this.memberStatus = status
+    }
 }

--- a/src/main/kotlin/codel/member/infrastructure/entity/ProfileEntity.kt
+++ b/src/main/kotlin/codel/member/infrastructure/entity/ProfileEntity.kt
@@ -42,7 +42,25 @@ class ProfileEntity(
             )
 
         private fun serializeAttribute(attribute: List<String>): String = attribute.joinToString(separator = ",")
+
+        private fun deserializeAttribute(attribute: String): List<String> = attribute.split(",")
     }
+
+    fun toDomain(): Profile =
+        Profile(
+            id = this.id,
+            codeName = this.codeName,
+            age = this.age,
+            job = this.job,
+            alcohol = this.alcohol,
+            smoke = this.smoke,
+            hobby = deserializeAttribute(this.hobby),
+            style = deserializeAttribute(this.style),
+            bigCity = this.bigCity,
+            smallCity = this.smallCity,
+            mbti = this.mbti,
+            introduce = this.introduce,
+        )
 
     fun updateCodeImage(codeImages: List<String>) {
         codeImage = serializeAttribute(codeImages)

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -1,7 +1,9 @@
 package codel.member.presentation
 
 import codel.auth.business.AuthService
+import codel.config.argumentresolver.LoginMember
 import codel.member.business.MemberService
+import codel.member.domain.Member
 import codel.member.presentation.request.CodeImageSavedRequest
 import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
@@ -39,8 +41,12 @@ class MemberController(
 
     @PostMapping("/v1/member/codeimage")
     override fun saveCodeImage(
+        @LoginMember member: Member,
         @RequestBody request: CodeImageSavedRequest,
     ): ResponseEntity<Unit> {
-        memberService.saveCodeImage(request)
+        // 이미지를 엔티티로 저장
+        // s3 통신 방식 변경 필요
+        memberService.saveCodeImage(member, request)
+        return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -33,9 +33,10 @@ class MemberController(
 
     @PostMapping("/v1/member/profile")
     override fun saveProfile(
+        @LoginMember member: Member,
         @RequestBody request: ProfileSavedRequest,
     ): ResponseEntity<Unit> {
-        memberService.saveProfile(request)
+        memberService.saveProfile(member, request)
         return ResponseEntity.ok().build()
     }
 

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -1,5 +1,7 @@
 package codel.member.presentation.swagger
 
+import codel.config.argumentresolver.LoginMember
+import codel.member.domain.Member
 import codel.member.presentation.request.CodeImageSavedRequest
 import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
@@ -46,6 +48,7 @@ interface MemberControllerSwagger {
         ],
     )
     fun saveCodeImage(
+        @LoginMember member: Member,
         @RequestBody request: CodeImageSavedRequest,
     ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -36,6 +36,7 @@ interface MemberControllerSwagger {
         ],
     )
     fun saveProfile(
+        @LoginMember member: Member,
         @RequestBody request: ProfileSavedRequest,
     ): ResponseEntity<Unit>
 

--- a/src/test/kotlin/codel/config/TestFixture.kt
+++ b/src/test/kotlin/codel/config/TestFixture.kt
@@ -35,7 +35,7 @@ class TestFixture {
                 oauthId = "hogee",
             )
 
-        memberRepository.loginMember(hogee)
+        hogee = memberRepository.loginMember(hogee)
 
         seokEntity =
             MemberEntity(

--- a/src/test/kotlin/codel/member/business/MemberServiceTest.kt
+++ b/src/test/kotlin/codel/member/business/MemberServiceTest.kt
@@ -1,9 +1,12 @@
 package codel.member.business
 
+import codel.config.TestFixture
 import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
 import codel.member.presentation.request.MemberLoginRequest
+import codel.member.presentation.request.ProfileSavedRequest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -13,14 +16,49 @@ import org.springframework.boot.test.context.SpringBootTest
 class MemberServiceTest(
     @Autowired
     private val memberService: MemberService,
-) {
+) : TestFixture() {
     @DisplayName("첫 로그인을 한 멤버의 상태는 SignUp 이다.")
     @Test
     fun loginMemberSuccessTest() {
-        val memberLoginRequest = MemberLoginRequest(OauthType.KAKAO, "hogee")
+        val memberLoginRequest =
+            MemberLoginRequest(
+                oauthType = OauthType.KAKAO,
+                oauthId = "hogee",
+            )
 
         val memberStatus = memberService.loginMember(memberLoginRequest).memberStatus
 
         assertThat(memberStatus).isEqualTo(MemberStatus.SIGNUP)
+    }
+
+    @DisplayName("프로필을 저장에 성공한 후 멤버 상태는 CODE_SURVEY 이다.")
+    @Test
+    fun saveProfileSuccessTest() {
+        val profileSavedRequest =
+            ProfileSavedRequest(
+                codeName = "seok",
+                age = 28,
+                job = "백엔드 개발자",
+                alcohol = "자주 마심",
+                smoke = "비흡연자 - 흡연자와 교류 NO",
+                hobby = listOf("영화 & 드라마", "여행 & 캠핑"),
+                style = listOf("표현을 잘하는 직진형", "상대가 필요할 때 항상 먼저 연락하는 스타일"),
+                bigCity = "경기도",
+                smallCity = "성남시",
+                mbti = "isfj",
+                introduce = "잘부탁드립니다!",
+            )
+        memberService.saveProfile(hogee, profileSavedRequest)
+
+        val findMember =
+            memberService.findMember(
+                oauthType = hogee.oauthType,
+                oauthId = hogee.oauthId,
+            )
+
+        Assertions.assertAll(
+            { assertThat(findMember.profile).isNotNull },
+            { assertThat(findMember.memberStatus).isEqualTo(MemberStatus.CODE_SURVEY) },
+        )
     }
 }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

프로필 저장 로직 수정

## 이슈 ID는 무엇인가요?

- close #16 

## 설명

1. AuthService의 의존성을 변경했습니다.
2. argumentResolver 로직을 filter에서 넘겨주는 값을 활용하도록 변경했습니다.
3. 프로필을 저장할 때 멤버와 매핑해주는 과정을 추가했습니다.
4. 프로필을 저장하면 멤버 상태가 CODE_SERVAY로 변경되도록 변경했습니다.


## 질문 혹은 공유 사항 (Optional)

1. AuthService가 기존에는 MemberRepository에 의존하는데 도메인끼리의 의존은 Service가 담당해야 하기 때문에 변경해봤습니다.
2. 기존 filter에서 request로 넘겨주는 값은 memberId인데 그럴 필요가 있나? 우리는 oauthId와 oauthType을 이용해 사용자를 판단하는데, memberId를 request로 넘겨주면 argumentResolver에서 memberId를 이용해 member로 매핑하는 과정이 추가된다.
3. @LoginMember (argumentResolver)를 사용해서 Member를 가져오는게 맞나? Controller에서 도메인인 Member를 아는게 맞을까? 
