### PR TITLE
[feature/#21] 페이스 이미지 저장 api 구현

### DIFF
--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -1,6 +1,7 @@
 package codel.member.business
 
 import codel.member.domain.CodeImage
+import codel.member.domain.FaceImage
 import codel.member.domain.ImageUploader
 import codel.member.domain.Member
 import codel.member.domain.MemberRepository
@@ -61,9 +62,20 @@ class MemberService(
         member: Member,
         files: List<MultipartFile>,
     ) {
-        val codeImage = uploadFile(files)
-        memberRepository.saveImagePath(member, codeImage)
+        val codeImage = uploadCodeImage(files)
+        memberRepository.saveCodeImage(member, codeImage)
     }
 
-    private fun uploadFile(files: List<MultipartFile>): CodeImage = CodeImage(files.map { file -> imageUploader.uploadFile(file) })
+    private fun uploadCodeImage(files: List<MultipartFile>): CodeImage = CodeImage(files.map { file -> imageUploader.uploadFile(file) })
+
+    @Transactional
+    fun saveFaceImage(
+        member: Member,
+        files: List<MultipartFile>,
+    ) {
+        val faceImage = uploadFaceImage(files)
+        memberRepository.saveFaceImage(member, faceImage)
+    }
+
+    private fun uploadFaceImage(files: List<MultipartFile>): FaceImage = FaceImage(files.map { file -> imageUploader.uploadFile(file) })
 }

--- a/src/main/kotlin/codel/member/domain/CodeImage.kt
+++ b/src/main/kotlin/codel/member/domain/CodeImage.kt
@@ -2,4 +2,8 @@ package codel.member.domain
 
 class CodeImage(
     val urls: List<String>,
-)
+) {
+    init {
+        require(urls.size in 1..3) { "얼굴 이미지 URL은 1개 이상 3개 이하이어야 합니다." }
+    }
+}

--- a/src/main/kotlin/codel/member/domain/FaceImage.kt
+++ b/src/main/kotlin/codel/member/domain/FaceImage.kt
@@ -2,4 +2,8 @@ package codel.member.domain
 
 class FaceImage(
     val urls: List<String>,
-)
+) {
+    init {
+        require(urls.size == 3) { "얼굴 이미지 URL은 정확히 3개여야 합니다." }
+    }
+}

--- a/src/main/kotlin/codel/member/domain/MemberRepository.kt
+++ b/src/main/kotlin/codel/member/domain/MemberRepository.kt
@@ -54,7 +54,7 @@ class MemberRepository(
         return memberJpaRepository.findByIdOrNull(memberId) ?: throw IllegalArgumentException("멤버가 존재하지 않습니다.")
     }
 
-    fun saveImagePath(
+    fun saveCodeImage(
         member: Member,
         codeImage: CodeImage,
     ) {
@@ -62,5 +62,15 @@ class MemberRepository(
             memberJpaRepository.findByIdOrNull(member.id) ?: throw IllegalArgumentException("해당 id 멤버 없음")
         memberEntity.updateCodeImage(codeImage)
         memberEntity.changeMemberStatus(MemberStatus.CODE_PROFILE_IMAGE)
+    }
+
+    fun saveFaceImage(
+        member: Member,
+        faceImage: FaceImage,
+    ) {
+        val memberEntity =
+            memberJpaRepository.findByIdOrNull(member.id) ?: throw IllegalArgumentException("해당 id 멤버 없음")
+        memberEntity.updateFaceImage(faceImage)
+        memberEntity.changeMemberStatus(MemberStatus.PENDING)
     }
 }

--- a/src/main/kotlin/codel/member/infrastructure/entity/MemberEntity.kt
+++ b/src/main/kotlin/codel/member/infrastructure/entity/MemberEntity.kt
@@ -1,6 +1,7 @@
 package codel.member.infrastructure.entity
 
 import codel.member.domain.CodeImage
+import codel.member.domain.FaceImage
 import codel.member.domain.Member
 import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
@@ -52,7 +53,11 @@ class MemberEntity(
     }
 
     fun updateCodeImage(codeImage: CodeImage) {
-        profileEntity!!.updateCodeImage(codeImage)
+        profileEntity?.updateCodeImage(codeImage)
+    }
+
+    fun updateFaceImage(faceImage: FaceImage) {
+        profileEntity?.updateFaceImage(faceImage)
     }
 
     fun changeMemberStatus(status: MemberStatus) {

--- a/src/main/kotlin/codel/member/infrastructure/entity/MemberEntity.kt
+++ b/src/main/kotlin/codel/member/infrastructure/entity/MemberEntity.kt
@@ -46,6 +46,7 @@ class MemberEntity(
             oauthId = this.oauthId,
             memberStatus = this.memberStatus,
             codeImage = profileEntity?.getCodeImage()?.let { CodeImage(it) },
+            faceImage = profileEntity?.getFaceImage()?.let { FaceImage(it) },
         )
 
     fun saveProfileEntity(profileEntity: ProfileEntity) {
@@ -53,11 +54,11 @@ class MemberEntity(
     }
 
     fun updateCodeImage(codeImage: CodeImage) {
-        profileEntity?.updateCodeImage(codeImage)
+        profileEntity!!.updateCodeImage(codeImage)
     }
 
     fun updateFaceImage(faceImage: FaceImage) {
-        profileEntity?.updateFaceImage(faceImage)
+        profileEntity!!.updateFaceImage(faceImage)
     }
 
     fun changeMemberStatus(status: MemberStatus) {

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -49,4 +49,13 @@ class MemberController(
         memberService.saveCodeImage(member, files)
         return ResponseEntity.ok().build()
     }
+
+    @PostMapping("/v1/member/faceimage")
+    override fun saveFaceImage(
+        @LoginMember member: Member,
+        @RequestPart files: List<MultipartFile>,
+    ): ResponseEntity<Unit> {
+        memberService.saveFaceImage(member, files)
+        return ResponseEntity.ok().build()
+    }
 }

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -53,4 +53,17 @@ interface MemberControllerSwagger {
         @LoginMember member: Member,
         @RequestPart files: List<MultipartFile>,
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "페이지 이미지 받기", description = "페이즈 이미지를 3장 받습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "페이스 이미지 성공적으로 저장됨"),
+            ApiResponse(responseCode = "400", description = "요청 값이 잘못됨"),
+            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+        ],
+    )
+    fun saveFaceImage(
+        @LoginMember member: Member,
+        @RequestPart files: List<MultipartFile>,
+    ): ResponseEntity<Unit>
 }

--- a/src/test/kotlin/codel/member/domain/CodeImageTest.kt
+++ b/src/test/kotlin/codel/member/domain/CodeImageTest.kt
@@ -1,0 +1,31 @@
+package codel.member.domain
+
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class CodeImageTest {
+    @DisplayName("페이스 이미지는 3장이여야 한다.")
+    @Test
+    fun initTest() {
+        assertAll(
+            {
+                assertDoesNotThrow {
+                    CodeImage(listOf("url1", "url2", "url3"))
+                }
+            },
+            {
+                assertThrows(IllegalArgumentException::class.java) {
+                    CodeImage(listOf())
+                }
+            },
+            {
+                assertThrows(IllegalArgumentException::class.java) {
+                    CodeImage(listOf("url1", "url2", "url3", "url4"))
+                }
+            },
+        )
+    }
+}

--- a/src/test/kotlin/codel/member/domain/FaceImageTest.kt
+++ b/src/test/kotlin/codel/member/domain/FaceImageTest.kt
@@ -1,0 +1,31 @@
+package codel.member.domain
+
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class FaceImageTest {
+    @DisplayName("페이스 이미지는 3장이여야 한다.")
+    @Test
+    fun initTest() {
+        assertAll(
+            {
+                assertDoesNotThrow {
+                    FaceImage(listOf("url1", "url2", "url3"))
+                }
+            },
+            {
+                assertThrows(IllegalArgumentException::class.java) {
+                    FaceImage(listOf("url1", "url2"))
+                }
+            },
+            {
+                assertThrows(IllegalArgumentException::class.java) {
+                    FaceImage(listOf("url1", "url2", "url3", "url4"))
+                }
+            },
+        )
+    }
+}

--- a/src/test/kotlin/codel/member/infrastructure/MemberJpaRepositoryTest.kt
+++ b/src/test/kotlin/codel/member/infrastructure/MemberJpaRepositoryTest.kt
@@ -3,7 +3,7 @@ package codel.member.infrastructure
 import codel.config.TestFixture
 import codel.member.domain.MemberStatus
 import codel.member.infrastructure.entity.MemberEntity
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -20,7 +20,7 @@ class MemberJpaRepositoryTest : TestFixture() {
                 oauthId = memberSignup.oauthId,
                 memberStatus = MemberStatus.SIGNUP,
             )
-        Assertions.assertThrows(DataIntegrityViolationException::class.java) {
+        assertThrows(DataIntegrityViolationException::class.java) {
             memberJpaRepository.save(newEntity)
         }
     }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

페이스 이미지 저장 api 구현

## 이슈 ID는 무엇인가요?

- close #21 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

- 얼굴 이미지를 받아 s3에 저장후 url을 db에 저장합니다.
- 얼굴 이미지는 3장이 강제되기에 검증 로직을 추가했습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
