### PR TITLE
[feature/#36] 코드 프로필 조회 API 구현 및 데이터베이스 클리너 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,27 +73,57 @@ jobs:
         run: |
           mkdir -p src/test/resources
           cat <<EOF > src/test/resources/application.yml
+          server:
+            port: 8080
+          
+          security:
+            jwt:
+              token:
+                expire-length: 3600000
+                secret-key: dummy-secret-key
+            admin:
+              password: dummy-admin-password
+          
+          cloud:
+            aws:
+              region:
+                static: ap-northeast-2
+              s3:
+                bucket: dummy-code-l-bucket
+              credentials:
+                access-key: dummy-access-key
+                secret-key: dummy-secret-key
+          
+          management:
+            endpoints:
+              web:
+                exposure:
+                  include: health, metrics, prometheus
+            metrics:
+              enable:
+                all: true
+          
           spring:
             datasource:
               driver-class-name: org.h2.Driver
               url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
               username: sa
               password:
-      
+          
             jpa:
+              open-in-view: false
               hibernate:
                 ddl-auto: create-drop
               show-sql: true
-              properties:
-                hibernate:
-                  format_sql: true
               database-platform: org.hibernate.dialect.H2Dialect
-      
+          
+          springdoc:
+            override-with-generic-response: false
+          
           logging:
             level:
               org.hibernate.SQL: debug
               org.hibernate.type.descriptor.sql.BasicBinder: trace
-          EOF
 
       - name: Restore firebase-adminsdk.json
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,6 +69,32 @@ jobs:
             override-with-generic-response: false
           EOF
 
+      - name: Generate application.yml for test
+        run: |
+          mkdir -p src/test/resources
+          cat <<EOF > src/test/resources/application.yml
+          spring:
+            datasource:
+              driver-class-name: org.h2.Driver
+              url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+              username: sa
+              password:
+      
+            jpa:
+              hibernate:
+                ddl-auto: create-drop
+              show-sql: true
+              properties:
+                hibernate:
+                  format_sql: true
+              database-platform: org.hibernate.dialect.H2Dialect
+      
+          logging:
+            level:
+              org.hibernate.SQL: debug
+              org.hibernate.type.descriptor.sql.BasicBinder: trace
+          EOF
+
       - name: Restore firebase-adminsdk.json
         run: |
           echo "$FIREBASE_CONFIG_JSON" > ./src/main/resources/code-l-b109b-firebase-adminsdk-fbsvc-8c4eb2e6f2.json

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,7 +80,7 @@ jobs:
             jwt:
               token:
                 expire-length: 3600000
-                secret-key: dummy-secret-key
+                secret-key: dummy-secret-key-should-be-long-enough-123456
             admin:
               password: dummy-admin-password
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,32 @@ jobs:
             override-with-generic-response: false
           EOF
 
+      - name: Generate application.yml for test
+        run: |
+          mkdir -p src/test/resources
+          cat <<EOF > src/test/resources/application.yml
+          spring:
+            datasource:
+              driver-class-name: org.h2.Driver
+              url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
+              username: sa
+              password:
+      
+            jpa:
+              hibernate:
+                ddl-auto: create-drop
+              show-sql: true
+              properties:
+                hibernate:
+                  format_sql: true
+              database-platform: org.hibernate.dialect.H2Dialect
+      
+          logging:
+            level:
+              org.hibernate.SQL: debug
+              org.hibernate.type.descriptor.sql.BasicBinder: trace
+          EOF
+
       - name: Restore firebase-adminsdk.json
         run: |
           echo "$FIREBASE_CONFIG_JSON" > ./src/main/resources/code-l-b109b-firebase-adminsdk-fbsvc-8c4eb2e6f2.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             jwt:
               token:
                 expire-length: 3600000
-                secret-key: dummy-secret-key
+                secret-key: dummy-secret-key-should-be-long-enough-123456
             admin:
               password: dummy-admin-password
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,22 +72,53 @@ jobs:
         run: |
           mkdir -p src/test/resources
           cat <<EOF > src/test/resources/application.yml
+          server:
+            port: 8080
+          
+          security:
+            jwt:
+              token:
+                expire-length: 3600000
+                secret-key: dummy-secret-key
+            admin:
+              password: dummy-admin-password
+          
+          cloud:
+            aws:
+              region:
+                static: ap-northeast-2
+              s3:
+                bucket: dummy-code-l-bucket
+              credentials:
+                access-key: dummy-access-key
+                secret-key: dummy-secret-key
+          
+          management:
+            endpoints:
+              web:
+                exposure:
+                  include: health, metrics, prometheus
+            metrics:
+              enable:
+                all: true
+          
           spring:
             datasource:
               driver-class-name: org.h2.Driver
               url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL
               username: sa
               password:
-      
+          
             jpa:
+              open-in-view: false
               hibernate:
                 ddl-auto: create-drop
               show-sql: true
-              properties:
-                hibernate:
-                  format_sql: true
               database-platform: org.hibernate.dialect.H2Dialect
-      
+          
+          springdoc:
+            override-with-generic-response: false
+          
           logging:
             level:
               org.hibernate.SQL: debug

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -8,8 +8,6 @@ import codel.member.domain.MemberRepository
 import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
 import codel.member.domain.Profile
-import codel.member.exception.MemberException
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -99,7 +97,7 @@ class MemberService(
     fun findRejectReason(member: Member): String = memberRepository.findRejectReason(member)
 
     fun findMemberProfile(member: Member): Member {
-        val memberId = member.id ?: throw MemberException(HttpStatus.BAD_REQUEST, "회원 ID가 존재하지 않습니다.")
+        val memberId = member.getIdOrThrow()
         return memberRepository.findMember(memberId)
     }
 }

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -8,6 +8,8 @@ import codel.member.domain.MemberRepository
 import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
 import codel.member.domain.Profile
+import codel.member.exception.MemberException
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -95,4 +97,9 @@ class MemberService(
     }
 
     fun findRejectReason(member: Member): String = memberRepository.findRejectReason(member)
+
+    fun findMemberProfile(member: Member): Member {
+        val memberId = member.id ?: throw MemberException(HttpStatus.BAD_REQUEST, "회원 ID가 존재하지 않습니다.")
+        return memberRepository.findMember(memberId)
+    }
 }

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -7,9 +7,11 @@ import codel.member.domain.Member
 import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
 import codel.member.presentation.response.MemberLoginResponse
+import codel.member.presentation.response.MemberProfileResponse
 import codel.member.presentation.swagger.MemberControllerSwagger
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestPart
@@ -75,5 +77,13 @@ class MemberController(
     ): ResponseEntity<Unit> {
         memberService.saveFcmToken(member, fcmToken)
         return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/v1/member/profile")
+    override fun findMemberProfile(
+        @LoginMember member: Member,
+    ): ResponseEntity<MemberProfileResponse> {
+        val findMember = memberService.findMemberProfile(member)
+        return ResponseEntity.ok(MemberProfileResponse.toResponse(findMember))
     }
 }

--- a/src/main/kotlin/codel/member/presentation/response/MemberProfileResponse.kt
+++ b/src/main/kotlin/codel/member/presentation/response/MemberProfileResponse.kt
@@ -1,0 +1,43 @@
+package codel.member.presentation.response
+
+import codel.member.domain.Member
+
+data class MemberProfileResponse(
+    val codeName: String,
+    val age: Int,
+    val job: String,
+    val alcohol: String,
+    val smoke: String,
+    val hobby: List<String>,
+    val style: List<String>,
+    val bigCity: String,
+    val smallCity: String,
+    val mbti: String,
+    val introduce: String,
+    val codeImages: List<String>,
+    val faceImages: List<String>,
+) {
+    companion object {
+        fun toResponse(member: Member): MemberProfileResponse {
+            val profile =
+                member.profile
+                    ?: throw IllegalArgumentException("회원 프로필이 존재하지 않습니다.")
+
+            return MemberProfileResponse(
+                codeName = profile.codeName,
+                age = profile.age,
+                job = profile.job,
+                alcohol = profile.alcohol,
+                smoke = profile.smoke,
+                hobby = profile.hobby,
+                style = profile.style,
+                bigCity = profile.bigCity,
+                smallCity = profile.smallCity,
+                mbti = profile.mbti,
+                introduce = profile.introduce,
+                codeImages = member.codeImage?.urls ?: emptyList(),
+                faceImages = member.faceImage?.urls ?: emptyList(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -5,6 +5,7 @@ import codel.member.domain.Member
 import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
 import codel.member.presentation.response.MemberLoginResponse
+import codel.member.presentation.response.MemberProfileResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
@@ -79,4 +80,16 @@ interface MemberControllerSwagger {
         @LoginMember member: Member,
         @RequestBody fcmToken: String,
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "작성된 사용자의 코드 프로필 확인", description = "작성된 사용자의 코드 프로필 정보를 받을 수 있습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "사용자 프로필을 성공적으로 가져옴"),
+            ApiResponse(responseCode = "400", description = "요청 값이 잘못됨"),
+            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+        ],
+    )
+    fun findMemberProfile(
+        @LoginMember member: Member,
+    ): ResponseEntity<MemberProfileResponse>
 }

--- a/src/test/kotlin/codel/config/DataCleanerExtension.kt
+++ b/src/test/kotlin/codel/config/DataCleanerExtension.kt
@@ -1,7 +1,7 @@
 package codel.config
 
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.ApplicationContext
@@ -11,9 +11,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.transaction.annotation.Transactional
 
 class DataCleanerExtension :
-    BeforeEachCallback,
+    AfterEachCallback,
     Loggable {
-    override fun beforeEach(extensionContext: ExtensionContext) {
+    override fun afterEach(extensionContext: ExtensionContext) {
         val applicationContext = SpringExtension.getApplicationContext(extensionContext)
 
         validateTransactionalAnnotationExists(extensionContext)

--- a/src/test/kotlin/codel/config/DataCleanerExtension.kt
+++ b/src/test/kotlin/codel/config/DataCleanerExtension.kt
@@ -1,0 +1,44 @@
+package codel.config
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.context.ApplicationContext
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.test.context.TestContextAnnotationUtils
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.transaction.annotation.Transactional
+
+class DataCleanerExtension :
+    BeforeEachCallback,
+    Loggable {
+    override fun beforeEach(extensionContext: ExtensionContext) {
+        val applicationContext = SpringExtension.getApplicationContext(extensionContext)
+
+        validateTransactionalAnnotationExists(extensionContext)
+        cleanDatabase(applicationContext)
+    }
+
+    private fun validateTransactionalAnnotationExists(extensionContext: ExtensionContext) {
+        if (TestContextAnnotationUtils.hasAnnotation(extensionContext.requiredTestClass, Transactional::class.java) ||
+            TestContextAnnotationUtils.hasAnnotation(extensionContext.requiredTestClass, jakarta.transaction.Transactional::class.java)
+        ) {
+            Assertions.fail<Unit>("테스트 클래스에 @Transactional 또는 @jakarta.transaction.Transactional 어노테이션이 존재합니다.")
+        }
+
+        if (AnnotatedElementUtils.hasAnnotation(extensionContext.requiredTestMethod, Transactional::class.java) ||
+            AnnotatedElementUtils.hasAnnotation(extensionContext.requiredTestMethod, jakarta.transaction.Transactional::class.java)
+        ) {
+            Assertions.fail<Unit>("테스트 메서드에 @Transactional 또는 @jakarta.transaction.Transactional 어노테이션이 존재합니다.")
+        }
+    }
+
+    private fun cleanDatabase(applicationContext: ApplicationContext) {
+        try {
+            DatabaseCleaner.clear(applicationContext)
+        } catch (e: NoSuchBeanDefinitionException) {
+            log.debug { "Database Cleaning not supported." }
+        }
+    }
+}

--- a/src/test/kotlin/codel/config/DatabaseCleaner.kt
+++ b/src/test/kotlin/codel/config/DatabaseCleaner.kt
@@ -1,0 +1,37 @@
+package codel.config
+
+import jakarta.persistence.EntityManager
+import org.springframework.context.ApplicationContext
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.transaction.support.TransactionTemplate
+
+object DatabaseCleaner {
+    fun clear(applicationContext: ApplicationContext) {
+        val entityManager = applicationContext.getBean(EntityManager::class.java)
+        val jdbcTemplate = applicationContext.getBean(JdbcTemplate::class.java)
+        val transactionTemplate = applicationContext.getBean(TransactionTemplate::class.java)
+
+        transactionTemplate.execute {
+            entityManager.clear()
+            deleteAll(jdbcTemplate, entityManager)
+            null
+        }
+    }
+
+    private fun deleteAll(
+        jdbcTemplate: JdbcTemplate,
+        entityManager: EntityManager,
+    ) {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate()
+
+        findDatabaseTableNames(jdbcTemplate).forEach { tableName ->
+            entityManager.createNativeQuery("DELETE FROM $tableName").executeUpdate()
+            entityManager.createNativeQuery("ALTER TABLE $tableName ALTER COLUMN id RESTART WITH 1").executeUpdate()
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate()
+    }
+
+    private fun findDatabaseTableNames(jdbcTemplate: JdbcTemplate): List<String> =
+        jdbcTemplate.query("SHOW TABLES") { rs, _ -> rs.getString(1) }
+}

--- a/src/test/kotlin/codel/config/TestFixture.kt
+++ b/src/test/kotlin/codel/config/TestFixture.kt
@@ -10,10 +10,12 @@ import codel.member.infrastructure.RejectReasonJpaRepository
 import codel.member.infrastructure.entity.MemberEntity
 import codel.member.infrastructure.entity.ProfileEntity
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
+@ExtendWith(DataCleanerExtension::class)
 class TestFixture {
     lateinit var memberSignup: Member
     lateinit var memberCodeSurvey: Member
@@ -37,10 +39,6 @@ class TestFixture {
 
     @BeforeEach
     fun setUp() {
-        rejectReasonJpaRepository.deleteAll()
-        memberJpaRepository.deleteAll()
-        profileJpaRepository.deleteAll()
-
         memberSignup = saveMemberSignup()
         memberCodeSurvey = saveMemberCodeSurvey()
         memberCodeProfileImage = saveMemberCodeProfileImage()


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

코드 프로필 조회 API 구현 및 데이터베이스 클리너 구현

## 이슈 ID는 무엇인가요?

- close #36 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

### 코드 프로필 조회 API
심사 이후 사용자의 코드 프로필 조회하는 API 입니다.

### 데이터베이스 클리너 객체 구현
테스트 자동화를 위해 데이터베이스 클리너 객체를 만들었습니다.

1. 데이터베이스 클리너 객체 구현
2. 매번 모든 테이블을 지우고 id 값을 1로 바꿈
3. 커스텀 어노테이션을 만들어 @BeforeEach 와 같은 작업을 매 테스트마다 하지 않아도 어노테이션으로 자동화
4. junit Extension 을 확장하여 구현
5. 테스트에 @Transactional 어노테이션을 쓰지 못하게 방지


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
