### PR TITLE
홈 코드 매칭 - 파도타기 구현

### DIFF
--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -10,6 +10,9 @@ import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
 import codel.member.domain.Profile
 import codel.member.infrastructure.MemberJpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -116,5 +119,19 @@ class MemberService(
         val excludeId = member.getIdOrThrow()
         val seed = DailySeedProvider.generateDailySeedForMember(excludeId)
         return memberJpaRepository.findRandomMembers(excludeId, 5, seed)
+    }
+
+    @Transactional(readOnly = true)
+    fun getRandomMembers(
+        page: Int,
+        size: Int,
+    ): Page<Member> {
+        val seed = DailySeedProvider.generateRandomSeed()
+        val offset = page * size
+        val members = memberJpaRepository.findMembersWithSeed(seed, size, offset)
+        val total = memberJpaRepository.count()
+        val pageable = PageRequest.of(page, size)
+
+        return PageImpl(members, pageable, total)
     }
 }

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -117,7 +117,7 @@ class MemberService(
     @Transactional(readOnly = true)
     fun recommendMembers(member: Member): List<Member> {
         val excludeId = member.getIdOrThrow()
-        val seed = DailySeedProvider.generateDailySeedForMember(excludeId)
+        val seed = DailySeedProvider.generateDailySeedForMember(member.getIdOrThrow())
         return memberJpaRepository.findRandomMembers(excludeId, 5, seed)
     }
 

--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -1,6 +1,7 @@
 package codel.member.business
 
 import codel.member.domain.CodeImage
+import codel.member.domain.DailySeedProvider
 import codel.member.domain.FaceImage
 import codel.member.domain.ImageUploader
 import codel.member.domain.Member
@@ -113,6 +114,7 @@ class MemberService(
     @Transactional(readOnly = true)
     fun recommendMembers(member: Member): List<Member> {
         val excludeId = member.getIdOrThrow()
-        return memberJpaRepository.findRandomMembers(excludeId, 5)
+        val seed = DailySeedProvider.generateDailySeedForMember(excludeId)
+        return memberJpaRepository.findRandomMembers(excludeId, 5, seed)
     }
 }

--- a/src/main/kotlin/codel/member/domain/DailySeedProvider.kt
+++ b/src/main/kotlin/codel/member/domain/DailySeedProvider.kt
@@ -1,0 +1,14 @@
+package codel.member.domain
+
+import java.time.LocalDate
+import kotlin.math.absoluteValue
+
+class DailySeedProvider {
+    companion object {
+        fun generateDailySeedForMember(memberId: Long): Long {
+            val today = LocalDate.now()
+            val key = "$memberId-$today"
+            return key.hashCode().toLong().absoluteValue
+        }
+    }
+}

--- a/src/main/kotlin/codel/member/domain/DailySeedProvider.kt
+++ b/src/main/kotlin/codel/member/domain/DailySeedProvider.kt
@@ -1,6 +1,7 @@
 package codel.member.domain
 
 import java.time.LocalDate
+import java.util.UUID
 import kotlin.math.absoluteValue
 
 class DailySeedProvider {
@@ -9,6 +10,11 @@ class DailySeedProvider {
             val today = LocalDate.now()
             val key = "$memberId-$today"
             return key.hashCode().toLong().absoluteValue
+        }
+
+        fun generateRandomSeed(): Long {
+            val uuid = UUID.randomUUID()
+            return (uuid.mostSignificantBits xor uuid.leastSignificantBits).absoluteValue
         }
     }
 }

--- a/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
+++ b/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
@@ -31,4 +31,14 @@ interface MemberJpaRepository : JpaRepository<Member, Long> {
         @Param("randomSize") randomSize: Long,
         @Param("recommendCode") seed: Long,
     ): List<Member>
+
+    @Query(
+        value = "SELECT * FROM member ORDER BY RAND(:seed) LIMIT :limit OFFSET :offset",
+        nativeQuery = true,
+    )
+    fun findMembersWithSeed(
+        @Param("seed") seed: Long,
+        @Param("limit") limit: Int,
+        @Param("offset") offset: Int,
+    ): List<Member>
 }

--- a/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
+++ b/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
@@ -23,11 +23,12 @@ interface MemberJpaRepository : JpaRepository<Member, Long> {
     fun findByMemberStatus(memberStatus: MemberStatus): List<Member>
 
     @Query(
-        value = "SELECT * FROM member WHERE id <> :excludeId ORDER BY RAND() LIMIT :randomSize",
+        value = "SELECT * FROM member WHERE id <> :excludeId ORDER BY RAND(:seed) LIMIT :randomSize",
         nativeQuery = true,
     )
     fun findRandomMembers(
         @Param("excludeId") excludeId: Long,
         @Param("randomSize") randomSize: Long,
+        @Param("recommendCode") seed: Long,
     ): List<Member>
 }

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -8,13 +8,16 @@ import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
 import codel.member.presentation.response.MemberLoginResponse
 import codel.member.presentation.response.MemberProfileResponse
+import codel.member.presentation.response.MemberRecommendResponse
 import codel.member.presentation.response.MemberRecommendResponses
 import codel.member.presentation.swagger.MemberControllerSwagger
+import org.springframework.data.domain.Page
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
@@ -94,5 +97,19 @@ class MemberController(
     ): ResponseEntity<MemberRecommendResponses> {
         val members = memberService.recommendMembers(member)
         return ResponseEntity.ok(MemberRecommendResponses.toResponse(members))
+    }
+
+    @GetMapping("/v1/member/all")
+    override fun getDailyRecommendMembers(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<Page<MemberRecommendResponse>> {
+        val memberPage = memberService.getRandomMembers(page, size)
+
+        return ResponseEntity.ok(
+            memberPage.map { member ->
+                MemberRecommendResponse.toResponse(member)
+            },
+        )
     }
 }

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -6,13 +6,16 @@ import codel.member.presentation.request.MemberLoginRequest
 import codel.member.presentation.request.ProfileSavedRequest
 import codel.member.presentation.response.MemberLoginResponse
 import codel.member.presentation.response.MemberProfileResponse
+import codel.member.presentation.response.MemberRecommendResponse
 import codel.member.presentation.response.MemberRecommendResponses
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.multipart.MultipartFile
 
@@ -105,4 +108,17 @@ interface MemberControllerSwagger {
     fun recommendMembers(
         @LoginMember member: Member,
     ): ResponseEntity<MemberRecommendResponses>
+
+    @Operation(summary = "홈 파도타기 조회", description = "홈 파도 타기 목록을 받습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "홈 파도 타기 목록 조회 성공"),
+            ApiResponse(responseCode = "400", description = "요청 값이 잘못됨"),
+            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+        ],
+    )
+    fun getDailyRecommendMembers(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<Page<MemberRecommendResponse>>
 }

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -94,6 +94,14 @@ interface MemberControllerSwagger {
         @LoginMember member: Member,
     ): ResponseEntity<MemberProfileResponse>
 
+    @Operation(summary = "홈 코드 추천 매칭 조회", description = "코드 추천 매칭 목록을 받습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "코드 추천 매칭 조회 성공"),
+            ApiResponse(responseCode = "400", description = "요청 값이 잘못됨"),
+            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+        ],
+    )
     fun recommendMembers(
         @LoginMember member: Member,
     ): ResponseEntity<MemberRecommendResponses>


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

<!-- 변경 사항에 대해서 간단하게 요약해 주세요 (자세한 내용은 아래 **설명** 부분에 적어주시면 됩니다.) -->

홈 코드 추천 매칭
- 하루마다 멤버 한명당 리스트 초기화가 되야함
  - 멤버랑 하루에 한번씩 변경되는 seed값을 만들어 하루동안은 같은 사람을 보게 수정

파도타기
- 매 호출마다 랜덤 리스트를 초기화 함
  - 하지만 페이지네이션 되어있기 때문에 다른 페이지를 넘어갔을 때 또 새로운 랜덤이 등장하면 안됨 (중복 이슈)
  - seed 값을 설정하여 하나의 페이지는 변경되지 않고 새로 호출 했을 때는 변경되도록 수정

## 이슈 ID는 무엇인가요?

- close #60 
