### PR TITLE
[fix#84] 멤버 전체 조회 기능 : 나를 제외한 데이터 제공하도록 수정

### DIFF
--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -136,13 +136,15 @@ class MemberService(
 
     @Transactional(readOnly = true)
     fun getRandomMembers(
+        member: Member,
         page: Int,
         size: Int,
     ): Page<Member> {
+        val excludeId = member.getIdOrThrow()
         val seed = DailySeedProvider.generateRandomSeed()
         val offset = page * size
-        val members = memberJpaRepository.findMembersWithSeedStatusDone(seed, size, offset)
-        val total = memberJpaRepository.count()
+        val members = memberJpaRepository.findMembersWithSeedStatusDoneExcludeMe(excludeId, seed, size, offset)
+        val total = memberJpaRepository.countMembersStatusDoneExcludeMe(excludeId)
         val pageable = PageRequest.of(page, size)
 
         return PageImpl(members, pageable, total)

--- a/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
+++ b/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
@@ -33,12 +33,21 @@ interface MemberJpaRepository : JpaRepository<Member, Long> {
     ): List<Member>
 
     @Query(
-        value = "SELECT * FROM member WHERE member_status = 'DONE' ORDER BY RAND(:seed) LIMIT :limit OFFSET :offset",
+        value = "SELECT * FROM member WHERE id <> :excludeId AND member_status = 'DONE' ORDER BY RAND(:seed) LIMIT :limit OFFSET :offset",
         nativeQuery = true,
     )
-    fun findMembersWithSeedStatusDone(
+    fun findMembersWithSeedStatusDoneExcludeMe(
+        @Param("excludeId") excludeId: Long,
         @Param("seed") seed: Long,
         @Param("limit") limit: Int,
         @Param("offset") offset: Int,
     ): List<Member>
+
+    @Query(
+        value = "SELECT COUNT(*) FROM member WHERE id <> :excludeId AND member_status = 'DONE'",
+        nativeQuery = true,
+    )
+    fun countMembersStatusDoneExcludeMe(
+        @Param("excludeId") excludeId: Long,
+    ): Long
 }

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -101,10 +101,11 @@ class MemberController(
 
     @GetMapping("/v1/member/all")
     override fun getDailyRecommendMembers(
+        @LoginMember member: Member,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
     ): ResponseEntity<Page<MemberResponse>> {
-        val memberPage = memberService.getRandomMembers(page, size)
+        val memberPage = memberService.getRandomMembers(member, page, size)
 
         return ResponseEntity.ok(
             memberPage.map { member ->

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -118,6 +118,7 @@ interface MemberControllerSwagger {
         ],
     )
     fun getDailyRecommendMembers(
+        @LoginMember member: Member,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
     ): ResponseEntity<Page<MemberResponse>>


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

멤버 전체 조회 기능 : 나를 제외한 데이터 제공하도록 수정

## 이슈 ID는 무엇인가요?

- #84 

## 설명

총 20개의 데이터가 있는 상태에서, 나를 제외한 데이터가 조회되도록 변경하였습니다.

<img width="524" height="300" alt="스크린샷 2025-07-14 오후 4 15 04" src="https://github.com/user-attachments/assets/6a1de4a8-3a63-4fd0-8553-a4c1d4a29a24" />

<img width="873" height="606" alt="스크린샷 2025-07-14 오후 4 23 02" src="https://github.com/user-attachments/assets/eb75016c-b9b1-48df-8057-f3c23a242a06" />


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
