### PR TITLE
[docs] Swagger에 노출된 인증 파라미터 제거

### DIFF
--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -9,6 +9,7 @@ import codel.member.presentation.response.MemberProfileResponse
 import codel.member.presentation.response.MemberRecommendResponses
 import codel.member.presentation.response.MemberResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -42,11 +43,12 @@ interface MemberControllerSwagger {
         ],
     )
     fun saveProfile(
-        @LoginMember member: Member,
+        @Parameter(hidden = true) @LoginMember member: Member,
         @RequestBody request: ProfileSavedRequest,
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "코드 프로필 이미지 받기", description = "코드 프로필 이미지 받습니다.")
+    @Operation(summary = "코드 프로필 이미지 받기",
+        description = "코드 프로필 이미지 받습니다. (※ Authorization 헤더에 JWT를 포함시켜야 합니다.)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "코드 프로필 이미지 성공적으로 저장됨"),
@@ -59,7 +61,8 @@ interface MemberControllerSwagger {
         @RequestPart files: List<MultipartFile>,
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "페이지 이미지 받기", description = "페이즈 이미지를 3장 받습니다.")
+    @Operation(summary = "페이지 이미지 받기",
+        description = "페이즈 이미지를 3장 받습니다. (※ Authorization 헤더에 JWT를 포함시켜야 합니다.)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "페이스 이미지 성공적으로 저장됨"),
@@ -68,11 +71,12 @@ interface MemberControllerSwagger {
         ],
     )
     fun saveFaceImage(
-        @LoginMember member: Member,
+        @Parameter(hidden = true) @LoginMember member: Member,
         @RequestPart files: List<MultipartFile>,
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "사용자별 fcm 토큰 받기", description = "사용자의 디바이스 별 fcm 토큰을 저장합니다.")
+    @Operation(summary = "사용자별 fcm 토큰 받기",
+        description = "사용자의 디바이스 별 fcm 토큰을 저장합니다. (※ Authorization 헤더에 JWT를 포함시켜야 합니다.)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "fcm 토큰 저장됨"),
@@ -81,11 +85,12 @@ interface MemberControllerSwagger {
         ],
     )
     fun saveFcmToken(
-        @LoginMember member: Member,
+        @Parameter(hidden = true) @LoginMember member: Member,
         @RequestBody fcmToken: String,
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "작성된 사용자의 코드 프로필 확인", description = "작성된 사용자의 코드 프로필 정보를 받을 수 있습니다.")
+    @Operation(summary = "작성된 사용자의 코드 프로필 확인",
+        description = "작성된 사용자의 코드 프로필 정보를 받을 수 있습니다. (※ Authorization 헤더에 JWT를 포함시켜야 합니다.)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "사용자 프로필을 성공적으로 가져옴"),
@@ -94,10 +99,11 @@ interface MemberControllerSwagger {
         ],
     )
     fun findMemberProfile(
-        @LoginMember member: Member,
+        @Parameter(hidden = true) @LoginMember member: Member,
     ): ResponseEntity<MemberProfileResponse>
 
-    @Operation(summary = "홈 코드 추천 매칭 조회", description = "코드 추천 매칭 목록을 받습니다.")
+    @Operation(summary = "홈 코드 추천 매칭 조회",
+        description = "코드 추천 매칭 목록을 받습니다. (※ Authorization 헤더에 JWT를 포함시켜야 합니다.)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "코드 추천 매칭 조회 성공"),
@@ -106,10 +112,11 @@ interface MemberControllerSwagger {
         ],
     )
     fun recommendMembers(
-        @LoginMember member: Member,
+        @Parameter(hidden = true) @LoginMember member: Member,
     ): ResponseEntity<MemberRecommendResponses>
 
-    @Operation(summary = "홈 파도타기 조회", description = "홈 파도 타기 목록을 받습니다.")
+    @Operation(summary = "홈 파도타기 조회",
+        description = "홈 파도 타기 목록을 받습니다. (※ Authorization 헤더에 JWT를 포함시켜야 합니다.)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "홈 파도 타기 목록 조회 성공"),
@@ -118,7 +125,7 @@ interface MemberControllerSwagger {
         ],
     )
     fun getDailyRecommendMembers(
-        @LoginMember member: Member,
+        @Parameter(hidden = true)@LoginMember member: Member,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
     ): ResponseEntity<Page<MemberResponse>>


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

Swagger 문서에 @LoginMember member: Member가 요청 파라미터처럼 노출되어 있어,
실제 JWT 인증 기반 로그인 방식과 맞지 않게 API 문서가 잘못 안내되고 있음.


## 이슈 ID는 무엇인가요?

- #86 

## 설명

	• @LoginMember member: Member에 @Parameter(hidden = true)를 적용하여 Swagger 문서에서 파라미터를 숨김 처리했습니다.
	• @Operation.description에 "Authorization 헤더에 JWT를 포함해야 합니다." 문구를 추가해 인증 방식 명시
	• Swagger 문서 상에서 해당 API 사용자가 직접 요청 파라미터를 넘겨야 하는 것으로 오해하지 않도록 개선하였습니다.

<img width="784" height="396" alt="스크린샷 2025-07-14 오후 4 46 11" src="https://github.com/user-attachments/assets/ca26bc4b-7127-4be6-8d94-2dac13dc0319" />


<!-- 필요 시 작성해 주세요. -->
