### PR TITLE
[feature/#94] 받은 시그널 조회 기능

### DIFF
--- a/src/main/kotlin/codel/signal/business/SignalService.kt
+++ b/src/main/kotlin/codel/signal/business/SignalService.kt
@@ -6,15 +6,17 @@ import codel.signal.domain.Signal
 import codel.signal.domain.SignalStatus
 import codel.signal.exception.SignalException
 import codel.signal.infrastructure.SignalRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 class SignalService(
     private val memberRepository: MemberRepository,
-    private val signalRepository: SignalRepository
+    private val signalRepository: SignalRepository,
 ) {
     @Transactional
     fun sendSignal(fromMember: Member, toMemberId: Long): Signal {
@@ -31,4 +33,16 @@ class SignalService(
             throw SignalException(HttpStatus.BAD_REQUEST, "자기 자신에게는 시그널을 보낼 수 없습니다.")
         }
     }
+
+    @Transactional(readOnly = true)
+    fun getReceivedSignals(
+        me: Member,
+        page: Int,
+        size: Int
+    ): Page<Signal>{
+        val pageable = PageRequest.of(page, size)
+        val receivedSignals = signalRepository.findByToMemberAndStatus(me, SignalStatus.PENDING)
+        return PageImpl(receivedSignals, pageable, receivedSignals.size.toLong())
+    }
+
 } 

--- a/src/main/kotlin/codel/signal/domain/Signal.kt
+++ b/src/main/kotlin/codel/signal/domain/Signal.kt
@@ -6,6 +6,7 @@ import codel.signal.exception.SignalException
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -20,9 +21,9 @@ class Signal(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     val fromMember: Member,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     val toMember: Member,
     @Enumerated(EnumType.STRING)
     var status: SignalStatus = SignalStatus.PENDING

--- a/src/main/kotlin/codel/signal/infrastructure/SignalRepository.kt
+++ b/src/main/kotlin/codel/signal/infrastructure/SignalRepository.kt
@@ -2,10 +2,16 @@ package codel.signal.infrastructure
 
 import codel.signal.domain.Signal
 import codel.member.domain.Member
+import codel.signal.domain.SignalStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface SignalRepository : JpaRepository<Signal, Long> {
     fun findTopByFromMemberAndToMemberOrderByIdDesc(fromMember: Member, toMember: Member): Signal?
+
+    @Query("SELECT s FROM Signal s JOIN FETCH s.fromMember fm JOIN FETCH fm.profile WHERE s.toMember = :member AND s.status= :status")
+    fun findByToMemberAndStatus(member: Member, @Param("status") signalStatus : SignalStatus) : List<Signal>
 } 

--- a/src/main/kotlin/codel/signal/presentation/SignalController.kt
+++ b/src/main/kotlin/codel/signal/presentation/SignalController.kt
@@ -5,6 +5,9 @@ import codel.signal.business.SignalService
 import codel.signal.presentation.request.SendSignalRequest
 import codel.signal.presentation.response.SignalResponse
 import codel.config.argumentresolver.LoginMember
+import codel.member.presentation.response.MemberResponse
+import codel.signal.presentation.response.ReceivedSignalResponse
+import org.springframework.data.domain.Page
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -20,5 +23,15 @@ class SignalController(
     ): ResponseEntity<SignalResponse> {
         val signal = signalService.sendSignal(fromMember, request.toMemberId)
         return ResponseEntity.ok(SignalResponse.from(signal))
+    }
+
+    @GetMapping("/received")
+    fun getMemberReceiveSignalForMe(
+        @LoginMember me: Member,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ) : ResponseEntity<Page<ReceivedSignalResponse>>{
+        val signals = signalService.getReceivedSignals(me, page, size)
+        return ResponseEntity.ok(signals.map { ReceivedSignalResponse.from(it)});
     }
 }

--- a/src/main/kotlin/codel/signal/presentation/response/ReceivedSignalResponse.kt
+++ b/src/main/kotlin/codel/signal/presentation/response/ReceivedSignalResponse.kt
@@ -1,0 +1,24 @@
+package codel.signal.presentation.response
+
+import codel.member.presentation.response.MemberProfileResponse
+import codel.signal.domain.Signal
+import codel.signal.domain.SignalStatus
+import java.time.LocalDateTime
+
+data class ReceivedSignalResponse(
+    val signalId: Long,
+    val fromMember: MemberProfileResponse,
+    val status: SignalStatus,
+    val createAt: LocalDateTime
+) {
+    companion object {
+        fun from(signal: Signal): ReceivedSignalResponse {
+            return ReceivedSignalResponse(
+                signalId = signal.id!!,
+                fromMember = MemberProfileResponse.toResponse(signal.fromMember),
+                status = signal.status,
+                createAt = signal.createdAt
+            )
+        }
+    }
+}

--- a/src/test/kotlin/codel/signal/business/SignalServiceTest.kt
+++ b/src/test/kotlin/codel/signal/business/SignalServiceTest.kt
@@ -20,6 +20,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import codel.signal.domain.SignalTestHelper
+import org.springframework.data.domain.PageImpl
 
 @ExtendWith(MockitoExtension::class)
 class SignalServiceTest {
@@ -152,5 +153,59 @@ class SignalServiceTest {
         // when & then
         val sendSignal = signalService.sendSignal(fromMember, toMemberId)
         assertThat(sendSignal.status).isEqualTo(SignalStatus.PENDING)
+    }
+
+    @DisplayName("여러 상태의 시그널 중 PENDING만 반환된다")
+    @Test
+    fun getReceivedSignals_onlyPending() {
+        // given
+        val me = mock(Member::class.java)
+        val fromMember1 = mock(Member::class.java)
+        val fromMember2 = mock(Member::class.java)
+        val pendingSignal = Signal(fromMember = fromMember1, toMember = me, status = SignalStatus.PENDING)
+        val acceptedSignal = Signal(fromMember = fromMember2, toMember = me, status = SignalStatus.ACCEPTED)
+        val rejectedSignal = Signal(fromMember = fromMember2, toMember = me, status = SignalStatus.REJECTED)
+        given(signalRepository.findByToMemberAndStatus(me, SignalStatus.PENDING)).willReturn(listOf(pendingSignal))
+
+        // when
+        val result = signalService.getReceivedSignals(me, 0, 10)
+
+        // then
+        assertThat(result.content).containsExactly(pendingSignal)
+        assertThat(result.content).doesNotContain(acceptedSignal, rejectedSignal)
+    }
+
+    @DisplayName("받은 시그널이 없을 때 빈 Page가 반환된다")
+    @Test
+    fun getReceivedSignals_empty() {
+        // given
+        val me = mock(Member::class.java)
+        given(signalRepository.findByToMemberAndStatus(me, SignalStatus.PENDING)).willReturn(emptyList())
+
+        // when
+        val result = signalService.getReceivedSignals(me, 0, 10)
+
+        // then
+        assertThat(result.content).isEmpty()
+        assertThat(result.totalElements).isEqualTo(0)
+    }
+
+    @DisplayName("toMember가 나(me)가 아닌 시그널은 결과에 포함되지 않는다")
+    @Test
+    fun getReceivedSignals_excludesOtherToMember() {
+        // given
+        val me = mock(Member::class.java)
+        val notMe = mock(Member::class.java)
+        val fromMember = mock(Member::class.java)
+        val signalForMe = Signal(fromMember = fromMember, toMember = me, status = SignalStatus.PENDING)
+        val signalForOther = Signal(fromMember = fromMember, toMember = notMe, status = SignalStatus.PENDING)
+        given(signalRepository.findByToMemberAndStatus(me, SignalStatus.PENDING)).willReturn(listOf(signalForMe))
+
+        // when
+        val result = signalService.getReceivedSignals(me, 0, 10)
+
+        // then
+        assertThat(result.content).containsExactly(signalForMe)
+        assertThat(result.content).doesNotContain(signalForOther)
     }
 } 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

받은 시그널 조회 기능 구현 추가

## 이슈 ID는 무엇인가요?

- #94 

## 설명

1. 받은 시그널 조회 기능 구현
    받은 시그널 중 대기 중(PENDING)인 상태만 조회됩니다.
2. 받은 시그널 테스트 코드 작성

## 질문사항

### 페이징 처리 관련
프로젝트에서 구현된 방법으로는 페이징 처리를 2가지 방식으로 진행하고 있는 것 같습니다.
  1. 디비에 page,size를 넘겨서 Page객체를 반환받는 방식
  4. 전체 데이터를 조회한 후, 애플리케이션에서 PageImpl을 이용해 페이징 처리하는 방식

제가 구현한 기능에선 시그널을 조회할 때 멤버 / 프로필에 대해 fetch join을 통해서 조회하고 있습니다.
저는 구현할 때 디비 페이징이 복잡한 페치조인 시 함께 쓰기 어렵다는 점과 데이터베이스에 최대한 부하를 줄이는 방식이 좋다고 생각하여 2번 방식으로 구현했습니다.
다만, 데이터가 엄청나게 많아질 경우에 OOM 위험도 있을 것 같습니다.
<img width="1156" height="420" alt="image" src="https://github.com/user-attachments/assets/7e2fb2d2-606c-4f38-9f2f-3aa7b18acb3c" />


그래서 호연님과 관석님께 두 가지 질문을 드리고 싶습니다.
1. 주로 어떤 페이징 방식을 사용하시나요? 두 가지 방식 외에도 다른 방식이 있다면 알려주시면 감사하겠습니다.
3. 위와 같은 상황이라면 어떻게 페이징 처리를 하실 것 같은가요?