### PR TITLE
Feature/#104

### DIFF
--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -134,8 +134,9 @@ class MemberService(
     fun recommendMembers(member: Member): List<Member> {
         val excludeId = member.getIdOrThrow()
         val seed = DailySeedProvider.generateDailySeedForMember(member.getIdOrThrow())
-        val candidateSize = 20L // 넉넉히 뽑아서 필터링
-        val candidates = memberJpaRepository.findRandomMembersStatusDone(excludeId, candidateSize, seed)
+        val candidateSize = 20 // 넉넉히 뽑아서 필터링
+        val pageable = PageRequest.of(0, candidateSize)
+        val candidates = memberJpaRepository.findRandomMembersStatusDoneWithProfile(excludeId, seed, pageable)
         if (candidates.isEmpty()) return emptyList()
 
         val now = LocalDateTime.now()

--- a/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
+++ b/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
@@ -3,10 +3,12 @@ package codel.member.infrastructure
 import codel.member.domain.Member
 import codel.member.domain.MemberStatus
 import codel.member.domain.OauthType
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.awt.print.Pageable
 
 @Repository
 interface MemberJpaRepository : JpaRepository<Member, Long> {
@@ -50,4 +52,14 @@ interface MemberJpaRepository : JpaRepository<Member, Long> {
     fun countMembersStatusDoneExcludeMe(
         @Param("excludeId") excludeId: Long,
     ): Long
+
+    @Query(
+        value = "SELECT m FROM Member m JOIN FETCH m.profile WHERE m.id <> :excludeId AND m.memberStatus = 'DONE' ORDER BY function('RAND', :seed)",
+        countQuery = "SELECT COUNT(m) FROM Member m WHERE m.id <> :excludeId AND m.memberStatus = 'DONE'"
+    )
+    fun findRandomMembersStatusDoneWithProfile(
+        @Param("excludeId") excludeId: Long,
+        @Param("seed") seed: Long,
+        pageRequest: PageRequest
+    ): List<Member>
 }

--- a/src/main/kotlin/codel/signal/infrastructure/SignalJpaRepository.kt
+++ b/src/main/kotlin/codel/signal/infrastructure/SignalJpaRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface SignalJpaRepository : JpaRepository<Signal, Long> {
@@ -17,4 +18,24 @@ interface SignalJpaRepository : JpaRepository<Signal, Long> {
 
     @Query("SELECT s FROM Signal s JOIN FETCH s.toMember tm JOIN FETCH tm.profile WHERE s.fromMember = :member AND s.status= :status")
     fun findByFromMemberAndStatus(me: Member, @Param("status") signalStatus: SignalStatus) : List<Signal>
+
+    @Query("""
+    SELECT s.toMember.id FROM Signal s
+    WHERE s.fromMember = :fromMember
+      AND s.toMember IN :candidates
+      AND (
+        (s.status = 'REJECTED' AND s.createdAt >= :sevenDaysAgo)
+        OR s.status IN ('ACCEPTED', 'ACCEPTED_HIDDEN', 'PENDING', 'PENDING_HIDDEN')
+      )
+      AND s.id IN (
+        SELECT MAX(s2.id) FROM Signal s2
+        WHERE s2.fromMember = :fromMember AND s2.toMember IN :candidates
+        GROUP BY s2.toMember
+      )
+    """)
+    fun findExcludedToMemberIds(
+        @Param("fromMember") fromMember: Member,
+        @Param("candidates") candidates: List<Member>,
+        @Param("sevenDaysAgo") sevenDaysAgo: LocalDateTime
+    ): List<Long>
 } 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

추천 멤버 필터링 기능 추가

## 이슈 ID는 무엇인가요?

- #104 

## 설명

1. 추천 멤버 필터링 기능 추가
1 + N + N 문제를 마주하고 해결하였습니다.
추천 멤버 필터링에서는 다음과 같은 과정을 회원들을 필터링합니다.
1. 시그널을 보내서 대기 중(PENDING / PENDING_HIDDEN) 멤버들을 제외합니다.
2. 시그널을 보내서 승인 된(APPOVED / APPROVED_HIDDEN) 멤버들을 제외합니다.
3. 시그널을 보내고 거절 된(REJECTED) 지 7일 이내의 회원들을 제외합니다.

로직은 다음과 같습니다.
1. 나를 제외한 회원을 조회합니다
2. 제외해야하는 멤버들에 대한 id값을 맵으로 만들고,
3. 1에서 조회한 회원 목록들을 순회하면서 제외되는 멤버 id 값을 제외합니다.
4. 3 과정을 진행하면서 5명의 멤버가 리스트업된다면 반환합니다.

N+1 문제와 맵을 적용하는 과정을 진행하면서
API 응답속도를 3.4ms -> 1.8ms -> 0.8ms로 개선하였습니다.

1. 1+N+N(멤버 조회 - 프로필 조회 - 시그널 조회)
<img width="1678" height="1472" alt="image" src="https://github.com/user-attachments/assets/8e1aac54-32d8-4622-8f38-2ddd42015c38" />


2. 1 + N + 1(멤버 조회 - 프로필 조회 - 시그널 조회)
<img width="1672" height="1358" alt="image" src="https://github.com/user-attachments/assets/9124d800-129e-4c92-8572-8b54456098fa" />


3. 1 + 1 + 1(멤버 조회 - 프로필 조회 - 시그널 조회)
<img width="829" height="749" alt="스크린샷 2025-07-15 오후 8 00 52" src="https://github.com/user-attachments/assets/3773512c-1605-4a06-8786-a5234df4218e" />


## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
