### PR TITLE
[fix/#108] 보낸 시그널 조회 API 수정

### DIFF
--- a/src/main/kotlin/codel/signal/infrastructure/SignalJpaRepository.kt
+++ b/src/main/kotlin/codel/signal/infrastructure/SignalJpaRepository.kt
@@ -16,8 +16,15 @@ interface SignalJpaRepository : JpaRepository<Signal, Long> {
     @Query("SELECT s FROM Signal s JOIN FETCH s.fromMember fm JOIN FETCH fm.profile WHERE s.toMember = :member AND s.status= :status")
     fun findByToMemberAndStatus(member: Member, @Param("status") signalStatus : SignalStatus) : List<Signal>
 
-    @Query("SELECT s FROM Signal s JOIN FETCH s.toMember tm JOIN FETCH tm.profile WHERE s.fromMember = :member AND s.status= :status")
-    fun findByFromMemberAndStatus(me: Member, @Param("status") signalStatus: SignalStatus) : List<Signal>
+    @Query("""
+    SELECT DISTINCT s FROM Signal s
+        JOIN FETCH s.fromMember fm
+        JOIN FETCH fm.profile
+        JOIN FETCH s.toMember tm
+        JOIN FETCH tm.profile
+        WHERE s.fromMember = :member AND s.status = :status
+    """)
+    fun findByFromMemberAndStatus(member: Member, @Param("status") signalStatus: SignalStatus) : List<Signal>
 
     @Query("""
     SELECT s.toMember.id FROM Signal s


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

보낸 시그널 조회 API 수정

## 이슈 ID는 무엇인가요?

- #108 

## 설명

@Query("""
    SELECT DISTINCT s
    FROM Signal s
    JOIN FETCH s.fromMember fm
    JOIN FETCH fm.profile
    JOIN FETCH s.toMember tm
    JOIN FETCH tm.profile
    WHERE s.fromMember = :member AND s.status = :status
""")
findByFromMemberAndStatus메서드의 쿼리를 변경하였습니다.

toMember에 대한 페치 조인이 되어있지 않아 컨트롤러에서 toMember의 프로필을 접근하려고하는 순간 
org.hibernate.LazyInitializationException 예외를 만났고, fetch join을 통해 데이터를 가져와 해결하였습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
