### PR TITLE
[feature/#111] 

### DIFF
--- a/src/main/kotlin/codel/chat/business/ChatService.kt
+++ b/src/main/kotlin/codel/chat/business/ChatService.kt
@@ -86,4 +86,10 @@ class ChatService(
 
         chatRepository.upsertLastChat(chatRoomId, requester, lastChat)
     }
+
+    fun updateUnlockChatRoom(requester: Member, chatRoomId: Long) {
+        val chatRoom = chatRoomRepository.findChatRoomById(chatRoomId)
+
+        chatRoom.unlock(requester.id!!)
+    }
 }

--- a/src/main/kotlin/codel/chat/domain/ChatRoom.kt
+++ b/src/main/kotlin/codel/chat/domain/ChatRoom.kt
@@ -1,5 +1,6 @@
 package codel.chat.domain
 
+import codel.chat.exception.ChatException
 import codel.common.domain.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -7,6 +8,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
 
 @Entity
 class ChatRoom(
@@ -16,6 +19,32 @@ class ChatRoom(
     @OneToOne
     @JoinColumn(name = "chat_id")
     var recentChat: Chat? = null,
+
+    var status : ChatRoomStatus = ChatRoomStatus.LOCKED,
+
+    var unlockedRequestedBy : Long? = null,
+
+    var unlockedUpdateAt : LocalDateTime? = null,
 ) : BaseTimeEntity() {
     fun getIdOrThrow(): Long = id ?: throw IllegalStateException("채팅방이 존재하지 않습니다.")
+
+    fun unlock(memberId : Long) {
+        when (status) {
+            ChatRoomStatus.LOCKED -> {
+                status = ChatRoomStatus.LOCKED_REQUESTED
+                unlockedUpdateAt = LocalDateTime.now()
+                unlockedRequestedBy = memberId
+            }
+            ChatRoomStatus.LOCKED_REQUESTED -> {
+                if (unlockedRequestedBy == memberId) {
+                    throw ChatException(HttpStatus.BAD_REQUEST, "이미 코드해제 요청을 보낸 상태입니다.")
+                }
+                status = ChatRoomStatus.UNLOCKED
+                unlockedUpdateAt = LocalDateTime.now()
+            }
+            ChatRoomStatus.UNLOCKED -> {
+                throw ChatException(HttpStatus.BAD_REQUEST, "이미 코드해제된 방입니다.")
+            }
+        }
+    }
 }

--- a/src/main/kotlin/codel/chat/domain/ChatRoomStatus.kt
+++ b/src/main/kotlin/codel/chat/domain/ChatRoomStatus.kt
@@ -1,0 +1,7 @@
+package codel.chat.domain
+
+enum class ChatRoomStatus(statusName : String) {
+    LOCKED("코드잠김"),
+    LOCKED_REQUESTED("코드해제_요청"),
+    UNLOCKED("코드해제"),
+}

--- a/src/main/kotlin/codel/chat/presentation/ChatController.kt
+++ b/src/main/kotlin/codel/chat/presentation/ChatController.kt
@@ -66,4 +66,13 @@ class ChatController(
 
         return ResponseEntity.noContent().build()
     }
+
+    @PostMapping("/v1/chatroom/{chatRoomId}/unlock")
+    fun updateChatRoomStatus(
+        @LoginMember requester : Member,
+        @PathVariable chatRoomId : Long,
+    ) : ResponseEntity<Unit> {
+        chatService.updateUnlockChatRoom(requester, chatRoomId)
+        return ResponseEntity.ok().build()
+    }
 }

--- a/src/main/kotlin/codel/chat/repository/ChatRoomRepository.kt
+++ b/src/main/kotlin/codel/chat/repository/ChatRoomRepository.kt
@@ -2,6 +2,7 @@ package codel.chat.repository
 
 import codel.chat.domain.ChatRoom
 import codel.chat.domain.ChatRoomMember
+import codel.chat.domain.ChatRoomStatus
 import codel.chat.exception.ChatException
 import codel.chat.infrastructure.ChatRoomJpaRepository
 import codel.chat.infrastructure.ChatRoomMemberJpaRepository

--- a/src/test/kotlin/codel/chat/domain/ChatRoomTest.kt
+++ b/src/test/kotlin/codel/chat/domain/ChatRoomTest.kt
@@ -1,0 +1,90 @@
+package codel.chat.domain
+
+import codel.chat.exception.ChatException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+
+class ChatRoomTest {
+    @DisplayName("LOCKED 상태에서 unlock을 하면 LOCKED_REQUESTED로 전이된다")
+    @Test
+    fun unlock_from_locked() {
+        // given
+        val chatRoom = ChatRoom(
+            id = 1L,
+            status = ChatRoomStatus.LOCKED
+        )
+        val memberId = 100L
+
+        // when
+        chatRoom.unlock(memberId)
+
+        // then
+        assertThat(chatRoom.status).isEqualTo(ChatRoomStatus.LOCKED_REQUESTED)
+        assertThat(chatRoom.unlockedRequestedBy).isEqualTo(memberId)
+        assertThat(chatRoom.unlockedUpdateAt).isNotNull()
+    }
+
+    @DisplayName("LOCKED_REQUESTED 상태에서 unlock을 다른 사용자가 하면 UNLOCKED로 전이된다")
+    @Test
+    fun unlock_from_lockedRequested_by_other() {
+        // given
+        val chatRoom = ChatRoom(
+            id = 1L,
+            status = ChatRoomStatus.LOCKED_REQUESTED,
+            unlockedRequestedBy = 100L,
+            unlockedUpdateAt = LocalDateTime.now().minusMinutes(1)
+        )
+        val otherMemberId = 200L
+
+        // when
+        chatRoom.unlock(otherMemberId)
+
+        // then
+        assertThat(chatRoom.status).isEqualTo(ChatRoomStatus.UNLOCKED)
+        assertThat(chatRoom.unlockedUpdateAt).isNotNull()
+    }
+
+    @DisplayName("LOCKED_REQUESTED 상태에서 unlock을 같은 사용자가 하면 예외가 발생한다")
+    @Test
+    fun unlock_from_lockedRequested_by_sameUser() {
+        // given
+        val memberId = 100L
+        val chatRoom = ChatRoom(
+            id = 1L,
+            status = ChatRoomStatus.LOCKED_REQUESTED,
+            unlockedRequestedBy = memberId,
+            unlockedUpdateAt = LocalDateTime.now().minusMinutes(1)
+        )
+
+        // when & then
+        val exception = assertThrows(ChatException::class.java) {
+            chatRoom.unlock(memberId)
+        }
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(exception.message).contains("이미 코드해제 요청을 보낸 상태입니다.")
+    }
+
+    @DisplayName("UNLOCKED 상태에서 unlock을 하면 예외가 발생한다")
+    @Test
+    fun unlock_from_unlocked() {
+        // given
+        val chatRoom = ChatRoom(
+            id = 1L,
+            status = ChatRoomStatus.UNLOCKED,
+            unlockedRequestedBy = 100L,
+            unlockedUpdateAt = LocalDateTime.now().minusMinutes(1)
+        )
+        val memberId = 200L
+
+        // when & then
+        val exception = assertThrows(ChatException::class.java) {
+            chatRoom.unlock(memberId)
+        }
+        assertThat(exception.status).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(exception.message).contains("이미 코드해제된 방입니다.")
+    }
+} 


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

채팅 중 코드해제 API

## 이슈 ID는 무엇인가요?

- #111

## 설명

1. 채팅 중 코드해제 API

2. 채팅 중 코드해제 테스트

코드해제 거절에 대해서는 추가적인 기획이 진행된 이후 변경할 것 같습니다.
현재는 ChatRoomStatus Enum 값을 통해 상태관리를 하고 있습니다.
LOCKED / LOCKED_REQUEST / UNLOCKED 3가지 상태로 상태관리가 이뤄집니다.
기획에서 거절처리를 어떻게 할 지 정해진 후에 REJECTED 상태가 추가 개발될 예정입니다.


## 질문 혹은 공유 사항 (Optional)