### PR TITLE
[feat] MemberProfileDetailResponse 응답 값에 isUnlocked 필드 추가

### DIFF
--- a/src/main/kotlin/codel/chat/business/ChatService.kt
+++ b/src/main/kotlin/codel/chat/business/ChatService.kt
@@ -1,5 +1,7 @@
 package codel.chat.business
 
+import codel.chat.exception.ChatException
+import codel.chat.infrastructure.ChatRoomJpaRepository
 import codel.chat.infrastructure.ChatRoomMemberJpaRepository
 import codel.chat.presentation.request.ChatRequest
 import codel.chat.presentation.request.CreateChatRoomRequest
@@ -11,8 +13,10 @@ import codel.chat.repository.ChatRepository
 import codel.chat.repository.ChatRoomRepository
 import codel.member.domain.Member
 import codel.member.domain.MemberRepository
+import codel.signal.infrastructure.SignalJpaRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,6 +27,8 @@ class ChatService(
     private val chatRepository: ChatRepository,
     private val memberRepository: MemberRepository,
     private val chatRoomMemberJpaRepository: ChatRoomMemberJpaRepository,
+    private val signalJpaRepository: SignalJpaRepository,
+    private val chatRoomJpaRepository: ChatRoomJpaRepository,
 ) {
     fun createChatRoom(
         requester: Member,
@@ -93,6 +99,6 @@ class ChatService(
     fun updateUnlockChatRoom(requester: Member, chatRoomId: Long) {
         val chatRoom = chatRoomRepository.findChatRoomById(chatRoomId)
 
-        chatRoom.unlock(requester.id!!)
+        chatRoom.unlock(requester.getIdOrThrow())
     }
 }

--- a/src/main/kotlin/codel/chat/infrastructure/ChatRoomJpaRepository.kt
+++ b/src/main/kotlin/codel/chat/infrastructure/ChatRoomJpaRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -22,4 +23,19 @@ interface ChatRoomJpaRepository : JpaRepository<ChatRoom, Long> {
         memberId: Long,
         pageable: Pageable,
     ): Page<ChatRoom>
+
+    @Query(
+        """
+    SELECT cr
+    FROM ChatRoom cr
+    JOIN ChatRoomMember crm1 ON crm1.chatRoom = cr
+    JOIN ChatRoomMember crm2 ON crm2.chatRoom = cr
+    WHERE crm1.member.id = :memberId
+      AND crm2.member.id = :partnerId
+    """
+    )
+    fun findChatRoomByMembers(
+        @Param("memberId") memberId : Long,
+        @Param("partnerId") partnerId : Long
+    ): ChatRoom?
 }

--- a/src/main/kotlin/codel/member/presentation/response/MemberProfileDetailResponse.kt
+++ b/src/main/kotlin/codel/member/presentation/response/MemberProfileDetailResponse.kt
@@ -20,8 +20,9 @@ data class MemberProfileDetailResponse(
     val question: String,
     val answer: String,
     val signalStatus : SignalStatus,
+    val isUnlocked: Boolean,
     val codeImages: List<String>,
-    val faceImages: List<String>,
+    val faceImages: List<String>
 ) {
     companion object {
         fun toResponse(member: Member, signalStatus : SignalStatus): MemberProfileDetailResponse {
@@ -45,6 +46,35 @@ data class MemberProfileDetailResponse(
                 question = profile.question,
                 answer = profile.answer,
                 signalStatus = signalStatus,
+                isUnlocked = false,
+                codeImages = profile.getCodeImageOrThrow(),
+                faceImages = profile.getFaceImageOrThrow(),
+            )
+        }
+
+
+        fun toResponse(member: Member, signalStatus : SignalStatus, isUnlocked : Boolean): MemberProfileDetailResponse {
+            val profile = member.getProfileOrThrow()
+
+            val deserializeHobby = Profile.deserializeAttribute(profile.hobby)
+            val deserializeStyle = Profile.deserializeAttribute(profile.style)
+            return MemberProfileDetailResponse(
+                memberId = member.getIdOrThrow(),
+                codeName = profile.codeName,
+                age = profile.age,
+                job = profile.job,
+                alcohol = profile.alcohol,
+                smoke = profile.smoke,
+                hobby = deserializeHobby,
+                style = deserializeStyle,
+                bigCity = profile.bigCity,
+                smallCity = profile.smallCity,
+                mbti = profile.mbti,
+                introduce = profile.introduce,
+                question = profile.question,
+                answer = profile.answer,
+                signalStatus = signalStatus,
+                isUnlocked = isUnlocked,
                 codeImages = profile.getCodeImageOrThrow(),
                 faceImages = profile.getFaceImageOrThrow(),
             )


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

MemberProfileDetailResponse 응답 값에 isUnlocked 필드 추가

## 이슈 ID는 무엇인가요?

- #157 

## 설명

isUnlocked 필드는 왜 필요했나?
상대방의 모든 정보를 확인 / 일부만 확인을 분기할 수 있는 수단이 필요한 상황이었습니다.

프로필 상세조회를 했을 때, 회원에 대한 정보를 얼마나 공개할지를 구분해야했습니다.

코드해제를 진행된 경우, 상대의 비공개 프로필, 추가 정보 등의 모든 정보를 확인할 수 있습니다.
하지만 코드해제를 하지 않은 경우엔 일부만 확인할 수 있습니다.

그래서 isUnlocked : Boolean 필드를 추가하여 상태를 분기할 수 있는 필드를 추가하였습니다.

isUnlocked가 true인 경우, 상대방의 모든 정보를 확인할 수 있습니다.
isUnlocked가 false인 경우, 상대방의 일부만 확인할 수 있습니다.

## 질문 혹은 공유 사항 (Optional)
