### PR TITLE
[feat] 파도타기 인원 8명으로 제한 + 10시마다 12시간 주기로 파도타기 회원 업데이트 되도록 변경

### DIFF
--- a/src/main/kotlin/codel/member/business/MemberService.kt
+++ b/src/main/kotlin/codel/member/business/MemberService.kt
@@ -204,13 +204,15 @@ class MemberService(
         val now = LocalDateTime.now()
         val todayMidnight = now.toLocalDate().atStartOfDay()
         val sevenDaysAgo = now.minusDays(7)
-        val candidates = memberJpaRepository.findMembersWithStatusDoneExcludeMe(member.getIdOrThrow())
+
+        val seed = DailySeedProvider.generateMemberSeedEveryTenHours(member.getIdOrThrow())
+        val candidates = memberJpaRepository.findRandomMembersStatusDone(member.getIdOrThrow(),seed)
 
         val allExcludeIds = makeExcludesMemberIds(member, candidates, sevenDaysAgo, todayMidnight)
 
         val result = candidates.filter { candidate ->
             candidate.id !in allExcludeIds
-        }
+        }.take(size)
 
         val pageable = PageRequest.of(page, size)
 

--- a/src/main/kotlin/codel/member/domain/DailySeedProvider.kt
+++ b/src/main/kotlin/codel/member/domain/DailySeedProvider.kt
@@ -1,6 +1,7 @@
 package codel.member.domain
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.*
 import kotlin.math.absoluteValue
 
@@ -15,6 +16,22 @@ class DailySeedProvider {
         fun generateRandomSeed(): Long {
             val uuid = UUID.randomUUID()
             return (uuid.mostSignificantBits xor uuid.leastSignificantBits).absoluteValue
+        }
+
+        fun generateMemberSeedEveryTenHours
+                    (memberId: Long) : Long{
+            val now = LocalDateTime.now()
+            val baseDate = if (now.hour < 10) {
+                // 아직 오전 10시 전이면 어제 날짜로 간주
+                now.toLocalDate().minusDays(1)
+            } else {
+                // 오전 10시 이후면 오늘 날짜
+                now.toLocalDate()
+            }
+            val isDayBlock = now.hour in 10..21 // 10:00 ~ 21:59
+
+            val key = "$memberId-$baseDate-BLOCK-${if (isDayBlock) "DAY" else "NIGHT"}"
+            return key.hashCode().toLong().absoluteValue
         }
     }
 }

--- a/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
+++ b/src/main/kotlin/codel/member/infrastructure/MemberJpaRepository.kt
@@ -27,12 +27,11 @@ interface MemberJpaRepository : JpaRepository<Member, Long> {
     fun countByMemberStatus(memberStatus: MemberStatus): Long
 
     @Query(
-        value = "SELECT * FROM member WHERE id <> :excludeId AND member_status = 'DONE' ORDER BY RAND(:seed) LIMIT :randomSize",
+        value = "SELECT * FROM member WHERE id <> :excludeId AND member_status = 'DONE' ORDER BY RAND(:seed)",
         nativeQuery = true,
     )
     fun findRandomMembersStatusDone(
         @Param("excludeId") excludeId: Long,
-        @Param("randomSize") randomSize: Long,
         @Param("seed") seed: Long,
     ): List<Member>
 

--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -96,10 +96,10 @@ class MemberController(
     }
 
     @GetMapping("/v1/member/all")
-    override fun getDailyRecommendMembers(
+    override fun getRecommendMemberAtTenHourCycle(
         @LoginMember member: Member,
         @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam(defaultValue = "8") size: Int,
     ): ResponseEntity<Page<MemberResponse>> {
         val memberPage = memberService.getRandomMembers(member, page, size)
 

--- a/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
+++ b/src/main/kotlin/codel/member/presentation/swagger/MemberControllerSwagger.kt
@@ -138,10 +138,10 @@ interface MemberControllerSwagger {
             ApiResponse(responseCode = "500", description = "서버 내부 오류"),
         ],
     )
-    fun getDailyRecommendMembers(
+    fun getRecommendMemberAtTenHourCycle(
         @Parameter(hidden = true) @LoginMember member: Member,
         @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam(defaultValue = "8") size: Int,
     ): ResponseEntity<Page<MemberResponse>>
 
     @Operation(


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

파도타기 인원 8명으로 제한 + 10시마다 12시간 주기로 파도타기 회원 업데이트 되도록 변경

## 이슈 ID는 무엇인가요?

- #174 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
