### PR TITLE
[hotfix] ci 오류 수정 : 메서드 명 변경(getUnlockedUpdateAt -> getUnlockedUpdate…

### DIFF
--- a/src/main/kotlin/codel/chat/domain/ChatRoom.kt
+++ b/src/main/kotlin/codel/chat/domain/ChatRoom.kt
@@ -54,5 +54,5 @@ class ChatRoom(
     }
 
 
-    fun getUnlockedUpdateAt() = unlockedUpdateAt ?: throw ChatException(HttpStatus.BAD_REQUEST, "코드 해제 요청 또는 승인한 적이 없습니다.")
+    fun getUnlockedUpdateAtOrThrow() = unlockedUpdateAt ?: throw ChatException(HttpStatus.BAD_REQUEST, "코드 해제 요청 또는 승인한 적이 없습니다.")
 }

--- a/src/main/kotlin/codel/signal/business/SignalService.kt
+++ b/src/main/kotlin/codel/signal/business/SignalService.kt
@@ -11,7 +11,6 @@ import codel.chat.infrastructure.ChatRoomJpaRepository
 import codel.chat.infrastructure.ChatRoomMemberJpaRepository
 import codel.member.domain.Member
 import codel.member.domain.MemberRepository
-import codel.member.presentation.response.MemberProfileResponse
 import codel.member.presentation.response.UnlockedMemberProfileResponse
 import codel.signal.domain.Signal
 import codel.signal.domain.SignalStatus
@@ -229,7 +228,7 @@ class SignalService(
         val chatRoomMembers =
             chatRoomMemberJpaRepository.findUnlockedOpponentsWithProfile(member, ChatRoomStatus.UNLOCKED, pageable)
         // 챗룸멤버를 멤버로 찾아온다.
-        return chatRoomMembers.map { chatRoomMember -> UnlockedMemberProfileResponse.toResponse(chatRoomMember.member, chatRoomMember.chatRoom.getUnlockedUpdateAt()) }
+        return chatRoomMembers.map { chatRoomMember -> UnlockedMemberProfileResponse.toResponse(chatRoomMember.member, chatRoomMember.chatRoom.getUnlockedUpdateAtOrThrow()) }
         // 챗룸멤버라는 리스트를 가져온 상태에서 챗룸의 정보를 가져온다.
         // 챗룸 상태가 코드해제된 방에 대해서 알아오고, 코드해제된 방 중 상대방에 대한 멤버 정보 + 프로필 정보를 함꼐 가져온다.
     }

--- a/src/test/kotlin/codel/chat/domain/ChatRoomTest.kt
+++ b/src/test/kotlin/codel/chat/domain/ChatRoomTest.kt
@@ -25,7 +25,7 @@ class ChatRoomTest {
         // then
         assertThat(chatRoom.status).isEqualTo(ChatRoomStatus.UNLOCKED_REQUESTED)
         assertThat(chatRoom.unlockedRequestedBy).isEqualTo(memberId)
-        assertThat(chatRoom.unlockedUpdateAt).isNotNull()
+        assertThat(chatRoom.getUnlockedUpdateAtOrThrow).isNotNull()
     }
 
     @DisplayName("LOCKED_REQUESTED 상태에서 unlock을 다른 사용자가 하면 UNLOCKED로 전이된다")
@@ -45,7 +45,7 @@ class ChatRoomTest {
 
         // then
         assertThat(chatRoom.status).isEqualTo(ChatRoomStatus.UNLOCKED)
-        assertThat(chatRoom.unlockedUpdateAt).isNotNull()
+        assertThat(chatRoom.getUnlockedUpdateAtOrThrow).isNotNull()
     }
 
     @DisplayName("LOCKED_REQUESTED 상태에서 unlock을 같은 사용자가 하면 예외가 발생한다")


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

ci 오류 수정 : 메서드 명 변경(getUnlockedUpdateAt -> getUnlockedUpdate

## 이슈 ID는 무엇인가요?

- #185 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
