### PR TITLE
[feat] 채팅 실시간 읽음 처리 기능

### DIFF
--- a/src/main/kotlin/codel/chat/business/ChatService.kt
+++ b/src/main/kotlin/codel/chat/business/ChatService.kt
@@ -1,9 +1,8 @@
 package codel.chat.business
 
-import codel.chat.exception.ChatException
 import codel.chat.infrastructure.ChatRoomJpaRepository
 import codel.chat.infrastructure.ChatRoomMemberJpaRepository
-import codel.chat.presentation.request.ChatRequest
+import codel.chat.presentation.request.ChatSendRequest
 import codel.chat.presentation.request.CreateChatRoomRequest
 import codel.chat.presentation.request.ChatLogRequest
 import codel.chat.presentation.response.ChatResponse
@@ -16,11 +15,9 @@ import codel.member.domain.MemberRepository
 import codel.signal.infrastructure.SignalJpaRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Transactional
 @Service
@@ -63,17 +60,17 @@ class ChatService(
     fun saveChat(
         chatRoomId: Long,
         requester: Member,
-        chatRequest: ChatRequest,
+        chatSendRequest: ChatSendRequest,
     ): SavedChatDto {
         val now = LocalDate.now()
-        val recentChatTime = chatRequest.recentChatTime
+        val recentChatTime = chatSendRequest.recentChatTime
 
         val chatRoom = chatRoomRepository.findChatRoomById(chatRoomId)
         if(now != recentChatTime.toLocalDate()) {
             val dateMessage = now.toString()
             chatRepository.saveDateChat(chatRoom, dateMessage)
         }
-        val savedChat = chatRepository.saveChat(chatRoomId, requester, chatRequest)
+        val savedChat = chatRepository.saveChat(chatRoomId, requester, chatSendRequest)
 
         chatRoom.updateRecentChat(savedChat)
 
@@ -99,10 +96,10 @@ class ChatService(
 
     fun updateLastChat(
         chatRoomId: Long,
-        chatLogRequest: ChatLogRequest,
+        lastReadChatId : Long,
         requester: Member,
     ) {
-        val lastChat = chatRepository.findChat(chatLogRequest.lastChatId)
+        val lastChat = chatRepository.findChat(lastReadChatId)
 
         chatRepository.upsertLastChat(chatRoomId, requester, lastChat)
     }

--- a/src/main/kotlin/codel/chat/domain/Chat.kt
+++ b/src/main/kotlin/codel/chat/domain/Chat.kt
@@ -1,7 +1,7 @@
 package codel.chat.domain
 
 import codel.chat.exception.ChatException
-import codel.chat.presentation.request.ChatRequest
+import codel.chat.presentation.request.ChatSendRequest
 import codel.member.domain.Member
 import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
@@ -32,14 +32,14 @@ class Chat(
     companion object {
         fun of(
             fromChatRoomMember: ChatRoomMember,
-            chatRequest: ChatRequest,
+            chatSendRequest: ChatSendRequest,
         ): Chat =
             Chat(
                 id = null,
                 chatRoom = fromChatRoomMember.chatRoom,
                 fromChatRoomMember = fromChatRoomMember,
-                message = chatRequest.message,
-                senderType = chatRequest.chatType,
+                message = chatSendRequest.message,
+                senderType = chatSendRequest.chatType,
                 chatContentType = ChatContentType.TEXT
             )
 

--- a/src/main/kotlin/codel/chat/presentation/ChatController.kt
+++ b/src/main/kotlin/codel/chat/presentation/ChatController.kt
@@ -59,7 +59,7 @@ class ChatController(
         @PathVariable chatRoomId: Long,
         @RequestBody chatLogRequest: ChatLogRequest,
     ): ResponseEntity<Unit> {
-        chatService.updateLastChat(chatRoomId, chatLogRequest, requester)
+        chatService.updateLastChat(chatRoomId, chatLogRequest.lastChatId, requester)
 
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/codel/chat/presentation/ChatWebSocketController.kt
+++ b/src/main/kotlin/codel/chat/presentation/ChatWebSocketController.kt
@@ -1,9 +1,11 @@
 package codel.chat.presentation
 
 import codel.chat.business.ChatService
-import codel.chat.presentation.request.ChatRequest
+import codel.chat.presentation.request.ChatSendRequest
+import codel.chat.presentation.request.UpdateLastChatRequest
 import codel.config.argumentresolver.LoginMember
 import codel.member.domain.Member
+import org.springdoc.webmvc.core.service.RequestService
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -14,19 +16,29 @@ import org.springframework.stereotype.Controller
 class ChatWebSocketController(
     private val messagingTemplate: SimpMessagingTemplate,
     private val chatService: ChatService,
+    private val requestService: RequestService,
 ) {
     @MessageMapping("/v1/chatroom/{chatRoomId}/chat")
     fun sendChat(
         @DestinationVariable("chatRoomId") chatRoomId: Long,
         @LoginMember requester: Member,
-        @Payload chatRequest: ChatRequest,
+        @Payload chatSendRequest: ChatSendRequest,
     ) {
-        val responseDto = chatService.saveChat(chatRoomId, requester, chatRequest)
+        val responseDto = chatService.saveChat(chatRoomId, requester, chatSendRequest)
 
         messagingTemplate.convertAndSend(
             "/sub/v1/chatroom/member/${responseDto.partner.id}",
             responseDto.chatRoomResponse,
         )
         messagingTemplate.convertAndSend("/sub/v1/chatroom/$chatRoomId", responseDto.chatResponse)
+    }
+
+    @MessageMapping("/v1/chatroom/{chatRoomId}")
+    fun readChat(
+        @DestinationVariable("chatRoomId") chatRoomId: Long,
+        @LoginMember requester : Member,
+        @Payload updateLastChatRequest: UpdateLastChatRequest,
+    ){
+        chatService.updateLastChat(chatRoomId, updateLastChatRequest.lastChatId, requester)
     }
 }

--- a/src/main/kotlin/codel/chat/presentation/request/ChatSendRequest.kt
+++ b/src/main/kotlin/codel/chat/presentation/request/ChatSendRequest.kt
@@ -3,7 +3,7 @@ package codel.chat.presentation.request
 import codel.chat.domain.ChatSenderType
 import java.time.LocalDateTime
 
-data class ChatRequest(
+data class ChatSendRequest(
     val message: String,
     val memberId: Long,
     val chatType: ChatSenderType,

--- a/src/main/kotlin/codel/chat/repository/ChatRepository.kt
+++ b/src/main/kotlin/codel/chat/repository/ChatRepository.kt
@@ -8,7 +8,7 @@ import codel.chat.exception.ChatException
 import codel.chat.infrastructure.ChatJpaRepository
 import codel.chat.infrastructure.ChatRoomJpaRepository
 import codel.chat.infrastructure.ChatRoomMemberJpaRepository
-import codel.chat.presentation.request.ChatRequest
+import codel.chat.presentation.request.ChatSendRequest
 import codel.member.domain.Member
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import java.time.LocalDateTime
 
 @Component
 class ChatRepository(
@@ -28,11 +27,11 @@ class ChatRepository(
     fun saveChat(
         chatRoomId: Long,
         requester: Member,
-        chatRequest: ChatRequest,
+        chatSendRequest: ChatSendRequest,
     ): Chat {
         val requesterChatRoomMember = findMe(chatRoomId, requester)
 
-        return chatJpaRepository.save(Chat.of(requesterChatRoomMember, chatRequest))
+        return chatJpaRepository.save(Chat.of(requesterChatRoomMember, chatSendRequest))
     }
 
     fun saveDateChat(chatRoom: ChatRoom, dateMessage: String) {


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

채팅 실시간 읽음 처리 기능

## 이슈 ID는 무엇인가요?

- #187

채팅을 읽으면 소켓 채널에 읽은 메시지 아이디를 전송합니다.
메시지 아이디값으로 채팅을 찾고, 사용자가 마지막으로 읽은 메시지를 업데이트합니다.

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
