### PR TITLE
[feat] 로그인 시 회원id를 반환하도록 수정

### DIFF
--- a/src/main/kotlin/codel/member/presentation/MemberController.kt
+++ b/src/main/kotlin/codel/member/presentation/MemberController.kt
@@ -32,7 +32,7 @@ class MemberController(
         return ResponseEntity
             .ok()
             .header("Authorization", "Bearer $token")
-            .body(MemberLoginResponse(member.memberStatus))
+            .body(MemberLoginResponse(member.getIdOrThrow(), member.memberStatus))
     }
 
     @PostMapping("/v1/member/profile")

--- a/src/main/kotlin/codel/member/presentation/response/MemberLoginResponse.kt
+++ b/src/main/kotlin/codel/member/presentation/response/MemberLoginResponse.kt
@@ -3,5 +3,6 @@ package codel.member.presentation.response
 import codel.member.domain.MemberStatus
 
 data class MemberLoginResponse(
+    val memberId : Long,
     val memberStatus: MemberStatus,
 )


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

[feat] 로그인 시 회원id를 반환하도록 수정

## 이슈 ID는 무엇인가요?

- #194

## 설명

소켓 통신을 하는 과정에서 로그인된 계정의 pk값을 알아야하는 상황이 있습니다.
현재 로그인된 계정의 pk값을 확인할 수 없었고, jwt로만 통신하고 있었습니다.
그래서 자신의pk값을 알지 못해 소켓통신을 할 때, 자신과 관련된 채널을 구독할 수 없었습니다.

로그인 시, 로그인된 계정의 pk값을 body값에 반환하여 프론트 캐시데이터로 저장하고 관리하여 자신과 관련된 채널을 구독하려고 합니다.

어플의 데이터 삭제할 경우, 관리되고 있던 pk값이 사라지지만 동일하게 jwt토큰 값도 사라지게 됩니다.
그렇기 떄문에 데이터를 삭제할 경우, 다시 로그인을 진행해야합니다.
다시 로그인을 해서 pk값과 jwt토큰을 받아와야합니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
