### PR TITLE
[bug] recentChatTime 타입 변경 : LocalDateTime -> LocalDateTime, 안드로이드와의 호환 문제 및 LocalDateTime으로 받지않아도 처리 가능함

### DIFF
--- a/src/main/kotlin/codel/chat/business/ChatService.kt
+++ b/src/main/kotlin/codel/chat/business/ChatService.kt
@@ -177,7 +177,7 @@ class ChatService(
         val recentChatTime = chatSendRequest.recentChatTime
 
         val chatRoom = chatRoomRepository.findChatRoomById(chatRoomId)
-        if(now != recentChatTime.toLocalDate()) {
+        if(now != recentChatTime) {
             val dateMessage = now.toString()
             chatRepository.saveDateChat(chatRoom, dateMessage)
         }

--- a/src/main/kotlin/codel/chat/presentation/request/ChatSendRequest.kt
+++ b/src/main/kotlin/codel/chat/presentation/request/ChatSendRequest.kt
@@ -1,11 +1,11 @@
 package codel.chat.presentation.request
 
 import codel.chat.domain.ChatSenderType
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class ChatSendRequest(
     val message: String,
     val memberId: Long,
     val chatType: ChatSenderType,
-    val recentChatTime: LocalDateTime,
+    val recentChatTime: LocalDate,
 )


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

recentChatTime 타입 변경 : LocalDateTime -> LocalDateTime, 안드로이드와의 호환 문제 및 LocalDateTime으로 받지않아도 처리 가능함

## 이슈 ID는 무엇인가요?

- #215

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
