### PR TITLE
[feature/#218] 마지막으로 읽은 채팅 기준으로 역순으로 채팅데이터 읽어오도록 기능 / ChatSenderType 제대로 반환되도록 수정

### DIFF
--- a/src/main/kotlin/codel/chat/business/ChatService.kt
+++ b/src/main/kotlin/codel/chat/business/ChatService.kt
@@ -217,6 +217,17 @@ class ChatService(
         return pagedChats.map { chat -> ChatResponse.toResponse(requester, chat) }
     }
 
+    @Transactional(readOnly = true)
+    fun getPreviousChats(
+        chatRoomId: Long,
+        lastChatId : Long?,
+        requester: Member,
+        pageable: Pageable,
+    ): Page<ChatResponse> {
+        val pagedChats = chatRepository.findPrevChats(chatRoomId, lastChatId, pageable)
+        return pagedChats.map { chat -> ChatResponse.toResponse(requester, chat) }
+    }
+
     fun updateLastChat(
         chatRoomId: Long,
         lastReadChatId : Long,

--- a/src/main/kotlin/codel/chat/domain/Chat.kt
+++ b/src/main/kotlin/codel/chat/domain/Chat.kt
@@ -69,7 +69,7 @@ class Chat(
     fun getChatType(requester: Member): ChatSenderType {
         return when {
             senderType == ChatSenderType.SYSTEM -> ChatSenderType.SYSTEM
-            requester == getFromChatRoomMemberOrThrow() -> ChatSenderType.MY
+            requester == getFromChatRoomMemberOrThrow().member -> ChatSenderType.MY
             else -> ChatSenderType.PARTNER
         }
     }

--- a/src/main/kotlin/codel/chat/infrastructure/ChatJpaRepository.kt
+++ b/src/main/kotlin/codel/chat/infrastructure/ChatJpaRepository.kt
@@ -73,11 +73,23 @@ interface ChatJpaRepository : JpaRepository<Chat, Long> {
     SELECT c
         FROM Chat c
         WHERE c.chatRoom = :chatRoom
-        AND c.id >= :lastChatId
         ORDER BY c.id ASC
     """)
     fun findNextChats(
         chatRoom: ChatRoom,
+        pageable: Pageable
+    ): Page<Chat>
+
+    @Query("""
+    SELECT c
+        FROM Chat c
+        WHERE c.chatRoom = :chatRoom
+        AND c.id <= :lastChatId
+        ORDER BY c.id DESC 
+    """)
+    fun findPrevChats(
+        chatRoom: ChatRoom,
+        lastChatId: Long,
         pageable: Pageable
     ): Page<Chat>
 }

--- a/src/main/kotlin/codel/chat/presentation/ChatController.kt
+++ b/src/main/kotlin/codel/chat/presentation/ChatController.kt
@@ -43,6 +43,18 @@ class ChatController(
         return ResponseEntity.ok(chatResponses)
     }
 
+    @GetMapping("/v1/chatroom/{chatRoomId}/chats/previous")
+    fun getPreviousChats(
+        @LoginMember requester: Member,
+        @PathVariable chatRoomId: Long,
+        @RequestParam(required = false) lastReadChatId: Long?,
+        @PageableDefault(size = 30, page = 0) pageable: Pageable,
+    ): ResponseEntity<Page<ChatResponse>> {
+        val chatResponses = chatService.getPreviousChats(chatRoomId, lastReadChatId, requester, pageable)
+
+        return ResponseEntity.ok(chatResponses)
+    }
+
     @PutMapping("/v1/chatroom/{chatRoomId}/last-chat")
     override fun updateLastChat(
         @LoginMember requester: Member,

--- a/src/main/kotlin/codel/chat/presentation/ChatController.kt
+++ b/src/main/kotlin/codel/chat/presentation/ChatController.kt
@@ -44,7 +44,7 @@ class ChatController(
     }
 
     @GetMapping("/v1/chatroom/{chatRoomId}/chats/previous")
-    fun getPreviousChats(
+    override fun getPreviousChats(
         @LoginMember requester: Member,
         @PathVariable chatRoomId: Long,
         @RequestParam(required = false) lastReadChatId: Long?,

--- a/src/main/kotlin/codel/chat/presentation/swagger/ChatControllerSwagger.kt
+++ b/src/main/kotlin/codel/chat/presentation/swagger/ChatControllerSwagger.kt
@@ -74,6 +74,42 @@ interface ChatControllerSwagger {
     ): ResponseEntity<Page<ChatResponse>>
 
     @Operation(
+        summary = "채팅방 이전 메시지 조회",
+        description = """
+            채팅방의 채팅 메시지 목록을 페이징하여 조회합니다.
+            
+            **파라미터 설명:**
+            - chatRoomId: 조회할 채팅방 ID (필수)
+            - lastChatId: 마지막으로 읽은 채팅 ID (선택, 무한스크롤 구현용)
+            - page: 페이지 번호 (기본값: 0)
+            - size: 페이지 크기 (기본값: 30)
+            
+            **사용 예시:**
+            - 최초 로드: GET /v1/chatroom/123/chats/previous?page=0&size=30
+            - 이전 메시지 로드: GET /v1/chatroom/123/chats/previous?lastChatId=456&page=0&size=30
+        """
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "성공적으로 채팅 목록 조회"),
+            ApiResponse(responseCode = "204", description = "이전 채팅 없음"),
+            ApiResponse(responseCode = "403", description = "해당 채팅방에 접근할 권한이 없음"),
+            ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음"),
+            ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+        ],
+    )
+    fun getPreviousChats(
+        @Parameter(hidden = true) @LoginMember requester: Member,
+        @Parameter(description = "채팅방 ID", required = true, example = "123")
+        @PathVariable chatRoomId: Long,
+        @Parameter(description = "마지막으로 읽은 채팅 ID (무한스크롤용)", required = false, example = "456")
+        @RequestParam(required = false) lastReadChatId: Long?,
+        @PageableDefault(size = 30, page = 0) pageable: Pageable,
+    ): ResponseEntity<Page<ChatResponse>>
+
+
+
+    @Operation(
         summary = "채팅방에서 마지막으로 읽은 채팅 업데이트",
         description = "채팅방을 나가면서 이 채팅방에서 내가 읽은 마지막 채팅 정보 저장",
     )

--- a/src/main/kotlin/codel/chat/repository/ChatRepository.kt
+++ b/src/main/kotlin/codel/chat/repository/ChatRepository.kt
@@ -57,6 +57,25 @@ class ChatRepository(
         return chatJpaRepository.findNextChats(chatRoom, lastChatId, pageableWithSort)
     }
 
+    fun findPrevChats(
+        chatRoomId: Long,
+        lastChatId: Long?,
+        pageable: Pageable,
+    ): Page<Chat> {
+        val pageableWithSort: Pageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, getChatDefaultSort())
+        val chatRoom =
+            chatRoomJpaRepository.findByIdOrNull(chatRoomId) ?: throw ChatException(
+                HttpStatus.BAD_REQUEST,
+                "채팅방을 찾을 수 없습니다.",
+            )
+
+        if(lastChatId == null){
+            throw ChatException(HttpStatus.NO_CONTENT, "이전 채팅이 존재하지 않습니다.")
+        }
+
+        return chatJpaRepository.findPrevChats(chatRoom, lastChatId, pageableWithSort)
+    }
+
     fun findChat(chatId: Long): Chat =
         chatJpaRepository.findByIdOrNull(chatId) ?: throw ChatException(
             HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

마지막으로 읽은 채팅 기준으로 역순으로 채팅데이터 읽어오도록 기능 / ChatSenderType 제대로 반환되도록 수정

## 이슈 ID는 무엇인가요?

- #218

## 설명

채팅을 주고받기 위해서 테스트 중, 채팅을 치면 상대방쪽에서 방금 입력한 메시지가 출력되는 문제를 발견했습니다.
ChatSenderType에 대한 비교가 Member와 ChatRoomMember가 비교되고 있던 상황이어서 항상 PARTNER로 분류되고 있던 문제가 발견되어 수정하였습니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
