### PR TITLE
[bug] 시그널 수락 시 질문을 주고 받을 때 chatRoom_question 테이블에 저장되도록 수정 + 첫 시작시 저장되는 메시지 수정

### DIFF
--- a/src/main/kotlin/codel/signal/business/SignalService.kt
+++ b/src/main/kotlin/codel/signal/business/SignalService.kt
@@ -32,13 +32,13 @@ class SignalService(
     private val asyncNotificationService: IAsyncNotificationService
 ) : Loggable {
     @Transactional
-    fun sendSignal(fromMember: Member, toMemberId: Long, message: String): Signal {
+    fun sendSignal(fromMember: Member, toMemberId: Long, message: String, myAnswer: String): Signal {
         validateNotSelf(fromMember.getIdOrThrow(), toMemberId)
         val toMember = memberRepository.findMember(toMemberId)
         val lastSignal = signalJpaRepository.findTopByFromMemberAndToMemberOrderByIdDesc(fromMember, toMember)
         lastSignal?.validateSendable()
 
-        val signal = Signal(fromMember = fromMember, toMember = toMember, message = message)
+        val signal = Signal(fromMember = fromMember, toMember = toMember, message = message, myAnswer = myAnswer)
         val savedSignal = signalJpaRepository.save(signal)
         
         // 알림 전송
@@ -119,7 +119,7 @@ class SignalService(
 
         val partner = findSignal.fromMember
         
-        val result = chatService.createInitialChatRoom(me, partner, approvedSignal.message)
+        val result = chatService.createInitialChatRoom(me, partner, approvedSignal.message, approvedSignal.myAnswer)
         
         // 매칭 성공 알림 전송 (양쪽 모두에게)
         sendMatchingSuccessNotification(me, partner)

--- a/src/main/kotlin/codel/signal/domain/Signal.kt
+++ b/src/main/kotlin/codel/signal/domain/Signal.kt
@@ -18,7 +18,8 @@ class Signal(
     @ManyToOne(fetch = FetchType.LAZY)
     val toMember: Member,
 
-    var message : String = "",
+    var message : String = "",  // 상대방(승인자) 질문에 대한 답변
+    var myAnswer : String = "",  // 내(발송자) 질문에 대한 답변
 
     @Enumerated(EnumType.STRING)
     var senderStatus: SignalStatus = SignalStatus.PENDING,

--- a/src/main/kotlin/codel/signal/presentation/SignalController.kt
+++ b/src/main/kotlin/codel/signal/presentation/SignalController.kt
@@ -27,7 +27,7 @@ class SignalController(
         @LoginMember fromMember: Member,
         @RequestBody request: SendSignalRequest
     ): ResponseEntity<SignalResponse> {
-        val signal = signalService.sendSignal(fromMember, request.toMemberId, request.message)
+        val signal = signalService.sendSignal(fromMember, request.toMemberId, request.message, request.myAnswer)
         return ResponseEntity.ok(SignalResponse.fromSend(signal))
     }
 

--- a/src/main/kotlin/codel/signal/presentation/request/SendSignalRequest.kt
+++ b/src/main/kotlin/codel/signal/presentation/request/SendSignalRequest.kt
@@ -2,5 +2,6 @@ package codel.signal.presentation.request
 
 data class SendSignalRequest(
     val toMemberId: Long,
-    val message: String
+    val message: String,  // 상대방(승인자) 질문에 대한 답변
+    val myAnswer: String  // 내(발송자) 질문에 대한 답변
 )


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

중복된 질문이 나온다는 문제가 있었습니다.
시그널 수락 시에 있었던 질문들을 기록하지 않음으로써 발생하던 중복문제라는 것을 확인하고,
시그널 수락 로직에 질문 저장하여 중복문제를 해결하였습니다.

## 이슈 ID는 무엇인가요?

- close #323

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
