### PR TITLE
[INFRA] 개발서버 배포 방식 최적화 - 블루그린 배포에서 중단 배포로 변경

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -187,12 +187,25 @@ jobs:
       - name: Push image to Docker Hub
         run: sudo docker push ${{ secrets.DOCKER_USERNAME }}/codel-app:dev
 
-      - name: Zero-downtime Blue-Green Deploy
+      - name: Deploy to Dev Server
         run: |
           echo "📦 이미지 정보: ${{ secrets.DOCKER_USERNAME }}/codel-app:dev"
 
-          echo "🔑 배포 스크립트 실행 권한 부여"
-          chmod +x ./scripts/blue-green-deploy.sh
+          echo "🛑 기존 컨테이너 중지 및 삭제"
+          sudo docker stop codel-app || true
+          sudo docker rm codel-app || true
 
-          echo "🚀 개발서버 무중단 배포 시작"
-          ./scripts/blue-green-deploy.sh ${{ secrets.DOCKER_USERNAME }}/codel-app:dev
+          echo "🔄 최신 이미지 pull"
+          sudo docker pull ${{ secrets.DOCKER_USERNAME }}/codel-app:dev
+
+          echo "🚀 개발서버 배포 시작"
+          sudo docker run -d \
+            --name codel-app \
+            -p 8080:8080 \
+            --restart unless-stopped \
+            ${{ secrets.DOCKER_USERNAME }}/codel-app:dev
+
+          echo "✅ 개발서버 배포 완료"
+
+          echo "🔍 컨테이너 상태 확인"
+          sudo docker ps | grep codel-app


### PR DESCRIPTION
  내용

  ## PR의 목적이 무엇인가요?

  개발서버(t2.micro)의 메모리 부족 문제 해결을 위한 배포 방식 최적화

  ## 이슈 ID는 무엇인가요?

  close #(이슈 번호)

  ## 설명

  ### 🔥 문제 상황

  개발서버 배포 중 메모리 부족으로 서버 과부하 발생

  **원인:**
  - t2.micro 인스턴스 (메모리 1GB)
  - 블루그린 배포 시 컨테이너 2개 동시 실행
  - 모니터링 + GitHub Runner + 애플리케이션 2개 = **메모리 초과**

  ### ✅ 해결 방법

  **블루그린 배포 → 중단 배포**로 변경

  #### 변경 전 (블루그린)
  ```bash
  새 컨테이너 실행 → Health Check → 포트포워딩 변경 → 기존 컨테이너 종료
  # 문제: 2-3단계에서 컨테이너 2개 동시 실행 (메모리 ~1000MB)

  변경 후 (중단 배포)

  🛑 기존 컨테이너 중지 및 삭제
  🔄 최신 이미지 pull
  🚀 새 컨테이너 실행
  ✅ 배포 완료
  # 개선: 항상 컨테이너 1개만 실행 (메모리 ~500MB)

  📊 메모리 사용량 비교

  | 항목      | 변경 전 (블루그린)  | 변경 후 (중단)   |
  |---------|--------------|-------------|
  | 애플리케이션  | ~1000MB (2개) | ~500MB (1개) |
  | 기타 프로세스 | ~150MB       | ~150MB      |
  | 합계      | ~1150MB ❌    | ~650MB ✅    |

  📂 변경된 파일

  .github/workflows/
  M cd-dev.yml       (배포 방식 변경: 블루그린 → 중단)

  주요 변경 내용:
  - blue-green-deploy.sh 스크립트 호출 → docker stop/rm/run 명령어로 변경
  - 배포 단계 간소화
  - 메모리 사용량 최적화

  🎯 기대 효과

  1. 안정성 향상: 메모리 부족으로 인한 서버 과부하 해결
  2. 배포 성공률 증가: 리소스 제약 없이 안정적인 배포
  3. 단순화: 복잡한 블루그린 로직 제거로 유지보수 용이

  ⚠️ Trade-off

  다운타임 발생
  - 배포 중 약 10-30초 서비스 중단
  - 개발서버 특성상 허용 가능한 수준

  운영서버는 영향 없음
  - cd-prod.yml은 그대로 블루그린 배포 유지
  - 무중단 배포 지속

  질문 혹은 공유 사항 (Optional)

  📝 배포 테스트 필요

  - develop 브랜치에 push하여 중단 배포 동작 확인
  - 배포 중 메모리 사용량 모니터링
  - 서비스 다운타임 측정 (예상: 10-30초)

  🔮 향후 계획

  - 개발서버 인스턴스 업그레이드 시 블루그린 배포 재적용 검토
  - 현재는 리소스 제약을 고려한 현실적인 선택