### PR TITLE
[refactor] 채팅알람 DTO 스펙 변경

### DIFF
--- a/src/main/kotlin/codel/notification/domain/Notification.kt
+++ b/src/main/kotlin/codel/notification/domain/Notification.kt
@@ -5,4 +5,5 @@ data class Notification(
     val targetId: String?, // 사용자 ID or null (예: Discord)
     val title: String,
     val body: String,
+    val data: Map<String, String>? = null, // FCM data payload (chatRoomId, senderId, type 등)
 )

--- a/src/main/kotlin/codel/notification/domain/NotificationDataType.kt
+++ b/src/main/kotlin/codel/notification/domain/NotificationDataType.kt
@@ -1,0 +1,54 @@
+package codel.notification.domain
+
+/**
+ * FCM 알림 데이터 타입
+ * 클라이언트에서 알림을 받았을 때 어떤 종류의 알림인지 구분하기 위한 타입
+ */
+enum class NotificationDataType(val value: String) {
+    /**
+     * 일반 채팅 메시지
+     */
+    CHAT("CHAT"),
+
+    /**
+     * 코드 해제 요청
+     */
+    CODE_UNLOCK_REQUEST("CODE_UNLOCK_REQUEST"),
+
+    /**
+     * 코드 해제 완료
+     */
+    CODE_UNLOCKED("CODE_UNLOCKED"),
+
+    /**
+     * 시그널(좋아요) 수신
+     */
+    SIGNAL("SIGNAL"),
+
+    /**
+     * 매칭 성공
+     */
+    MATCHING("MATCHING"),
+
+    /**
+     * 프로필 승인
+     */
+    PROFILE_APPROVED("PROFILE_APPROVED"),
+
+    /**
+     * 프로필 반려
+     */
+    PROFILE_REJECTED("PROFILE_REJECTED"),
+
+    /**
+     * 일일 매칭 알림 (데일리 코드)
+     */
+    DAILY_MATCHING("DAILY_MATCHING"),
+
+    /**
+     * 시스템 공지사항
+     */
+    NOTICE("NOTICE");
+
+    override fun toString(): String = value
+}


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

  FCM 푸시 알림에 구조화된 메타데이터(data 필드)를 추가하여
  클라이언트에서 현재 채팅방 필터링 및 딥링크 처리가 가능하도록 개선

  ## 이슈 ID는 무엇인가요?

  - closes #356

  ## 설명

  ### 🎯 변경 배경

  기존 FCM 알림은 `notification` 필드(title, body)만 전송하여 다음과 같은
   문제가 있었습니다:

  - ❌ **현재 채팅방 필터링 불가**: 사용자가 채팅 중인 채팅방에서도
  알림이 표시됨
  - ❌ **딥링크 정보 부족**: 알림 탭 시 어떤 채팅방으로 이동할지 알 수
  없음
  - ❌ **읽음 위치 추적 불가**: 마지막 읽은 메시지 정보 없음
  - ❌ **알림 타입 구분 불가**: 일반 채팅, 시스템 알림 등을 구분할 수
  없음

  ### ✅ 주요 변경 사항

  #### 1. `Notification` 도메인 모델 확장
  ```kotlin
  data class Notification(
      val type: NotificationType,
      val targetId: String?,
      val title: String,
      val body: String,
      val data: Map<String, String>? = null  // 🆕 추가
  )

  2. NotificationDataType Enum 생성

  enum class NotificationDataType(val value: String) {
      CHAT("CHAT"),
      CODE_UNLOCK_REQUEST("CODE_UNLOCK_REQUEST"),
      CODE_UNLOCKED("CODE_UNLOCKED"),
      SIGNAL("SIGNAL"),
      MATCHING("MATCHING"),
      // ...
  }

  하드코딩 대신 타입 안전성을 확보했습니다.

  3. FcmNotificationSender data 필드 처리

  notification.data?.let { data ->
      messageBuilder.putAllData(data)
  }

  4. ChatService.sendChatNotification data 전달

  data = mapOf(
      "type" to NotificationDataType.CHAT.value,
      "chatRoomId" to chatRoomId.toString(),
      "lastReadChatId" to savedChat.getIdOrThrow().toString()
  )

  📦 전송 데이터 구조

  Before:
  {
    "notification": {
      "title": "코드네임",
      "body": "안녕하세요"
    }
  }

  After:
  {
    "notification": {
      "title": "코드네임",
      "body": "안녕하세요"
    },
    "data": {
      "type": "CHAT",
      "chatRoomId": "123",
      "lastReadChatId": "789"
    }
  }

  📝 변경된 파일

  - src/main/kotlin/codel/notification/domain/Notification.kt - data 필드
   추가
  - src/main/kotlin/codel/notification/domain/NotificationDataType.kt -
  Enum 클래스 신규 생성
  - src/main/kotlin/codel/notification/domain/sender/FcmNotificationSende
  r.kt - data 필드 FCM 메시지에 포함
  - src/main/kotlin/codel/chat/business/ChatService.kt - 채팅 전송 시
  data 전달

  🔍 적용 범위

  - ✅ 채팅 메시지 전송 시: data 필드 포함
  - ⚪ 코드 해제 알림: 기존 방식 유지 (향후 확장 가능)
  - ⚪ 시그널/매칭 알림: 기존 방식 유지 (향후 확장 가능)

  📱 클라이언트 대응 필요 사항

  1. 포어그라운드 처리 로직
  override fun onMessageReceived(remoteMessage: RemoteMessage) {
      val chatRoomId = remoteMessage.data["chatRoomId"]?.toLong()

      // 현재 채팅방이면 알림 표시 안 함
      if (currentChatRoomId == chatRoomId) {
          return
      }

      showNotification(...)
  }
  2. 딥링크 처리
    - data.chatRoomId로 특정 채팅방으로 이동
    - data.lastReadChatId로 읽지 않은 메시지 표시

  🚀 향후 확장 계획

  NotificationDataType Enum을 활용하여 다른 알림에도 동일한 방식 적용
  가능:
  - CODE_UNLOCK_REQUEST: 코드 해제 요청 시 chatRoomId 포함
  - SIGNAL: 시그널 수신 시 senderId 포함
  - MATCHING: 매칭 성공 시 chatRoomId 포함

  질문 혹은 공유 사항 (Optional)

  ⚠️ 주의사항

  - FCM data 필드의 value는 모두 String 타입이어야 함
  (chatRoomId.toString() 필수)
  - 기존 알림(코드 해제, 시그널 등)은 기존 방식 유지하여 클라이언트
  호환성 보장
  - 클라이언트에서 포어그라운드 필터링 로직 구현 필요

  💡 참고

  - FCM 공식 문서: https://firebase.google.com/docs/cloud-messaging/conce
  pt-options#data_messages
  - data 필드는 백그라운드에서도 전달되지만, notification과 함께 있을
  때는 notification이 우선 표시됨
