### PR TITLE
[refactor] 채팅 알람을 제외한 FCM 알람 data.type = NOTICE 추가

### DIFF
--- a/src/main/kotlin/codel/notification/domain/sender/FcmNotificationSender.kt
+++ b/src/main/kotlin/codel/notification/domain/sender/FcmNotificationSender.kt
@@ -1,6 +1,7 @@
 package codel.notification.domain.sender
 
 import codel.config.Loggable
+import codel.notification.domain.NotificationDataType
 import codel.notification.domain.NotificationType
 import codel.notification.exception.NotificationException
 import com.google.firebase.messaging.*
@@ -24,10 +25,10 @@ class FcmNotificationSender : NotificationSender, Loggable {
                     .build(),
             )
 
-        // data 필드가 있으면 추가
-        notification.data?.let { data ->
-            messageBuilder.putAllData(data)
-        }
+        // 기본값으로 NOTICE 타입 설정 후, 요청 data로 덮어쓰기
+        val defaultData = mapOf("type" to NotificationDataType.NOTICE.value)
+        val dataToSend = defaultData + (notification.data ?: emptyMap())
+        messageBuilder.putAllData(dataToSend)
 
         val message = messageBuilder.build()
 
@@ -62,10 +63,10 @@ class FcmNotificationSender : NotificationSender, Loggable {
                         .build(),
                 )
 
-            // data 필드가 있으면 추가
-            notification.data?.let { data ->
-                messageBuilder.putAllData(data)
-            }
+            // 기본값으로 NOTICE 타입 설정 후, 요청 data로 덮어쓰기
+            val defaultData = mapOf("type" to NotificationDataType.NOTICE.value)
+            val dataToSend = defaultData + (notification.data ?: emptyMap())
+            messageBuilder.putAllData(dataToSend)
 
             messageBuilder.build()
         }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

  FcmNotificationSender에서 기본값으로 NOTICE 타입을 자동 설정하여,
  모든 서비스 코드에서 type을 반복 명시할 필요 없도록 개선

  ## 이슈 ID는 무엇인가요?

  - closes #358

  ## 설명

  ### 🎯 변경 배경

  FCM 알림 전송 시 모든 서비스 코드에서 `data` 필드에 `type`을
  반복적으로 명시해야 하는 문제가 있었습니다:

  **기존 방식의 문제점:**
  ```kotlin
  // AdminService, SignalService, CodeUnlockService 등 모든 곳에서
  반복
  data = mapOf("type" to NotificationDataType.NOTICE.value)

  - ❌ 코드 중복: 동일한 type 설정 코드가 여러 곳에 산재
  - ❌ 확장성 저하: 새 알림 추가 시 type도 매번 명시 필요
  - ❌ 누락 위험: 개발자가 type을 빠뜨릴 가능성
  - ❌ 유지보수 비용: 모든 서비스 코드 수정 필요

  ✅ 개선 사항

  ⭐ FcmNotificationSender에서 기본값 설정 + 덮어쓰기 패턴 적용

  // Before
  val dataToSend = notification.data ?: mapOf("type" to
  NotificationDataType.NOTICE.value)
  messageBuilder.putAllData(dataToSend)

  // After
  val defaultData = mapOf("type" to
  NotificationDataType.NOTICE.value)
  val dataToSend = defaultData + (notification.data ?: emptyMap())
  messageBuilder.putAllData(dataToSend)

  핵심 개선점:
  - 🔹 기본값 자동 설정: data가 없어도 type: NOTICE 자동 추가
  - 🔹 덮어쓰기 지원: data에 type이 있으면 기본값 위에 덮어씀
  - 🔹 단일 지점 수정: FcmNotificationSender 한 곳만 수정

  📝 변경된 파일

  src/main/kotlin/codel/notification/domain/sender/FcmNotificationSen
  der.kt

  1. send() 메서드 (28-31줄)

  // 기본값으로 NOTICE 타입 설정 후, 요청 data로 덮어쓰기
  val defaultData = mapOf("type" to
  NotificationDataType.NOTICE.value)
  val dataToSend = defaultData + (notification.data ?: emptyMap())
  messageBuilder.putAllData(dataToSend)

  2. sendBatch() 메서드 (66-69줄)

  // 배치 전송에도 동일한 패턴 적용
  val defaultData = mapOf("type" to
  NotificationDataType.NOTICE.value)
  val dataToSend = defaultData + (notification.data ?: emptyMap())
  messageBuilder.putAllData(dataToSend)

  🎯 사용 예시

  1️⃣ 일반 알림 (data 없음)

  // AdminService, SignalService 등
  val notification = Notification(
      type = NotificationType.MOBILE,
      targetId = token,
      title = "프로필 심사가 완료되었어요 ✅",
      body = "..."
      // data 전달 안 해도 됨!
  )
  → 결과: {"type": "NOTICE"}

  2️⃣ 채팅 알림 (type 명시적 변경)

  // ChatService - 기존대로 type 덮어쓰기
  data = mapOf(
      "type" to NotificationDataType.CHAT.value,  // NOTICE → 
  CHAT으로 덮어씀
      "chatRoomId" to "123",
      "lastReadChatId" to "456"
  )
  → 결과: {"type": "CHAT", "chatRoomId": "123", "lastReadChatId": 
  "456"}

  3️⃣ 향후 확장 (type 명시 불필요)

  // 새로운 알림에 추가 data만 전달 - type은 자동으로 NOTICE
  data = mapOf(
      "userId" to "789",
      "eventId" to "abc"
  )
  → 결과: {"type": "NOTICE", "userId": "789", "eventId": "abc"}

  🚀 효과

  1. ✅ 코드 간소화: 서비스 코드에서 type 명시 불필요
  2. ✅ 단일 책임: FcmNotificationSender만 type 관리
  3. ✅ 확장성: 새 알림 추가 시 type 신경 쓸 필요 없음
  4. ✅ 하위 호환성: 기존 코드 그대로 동작 (덮어쓰기)

  📊 Before / After 비교

  | 항목      | Before          | After                  |
  |---------|-----------------|------------------------|
  | type 명시 | 모든 서비스 코드에서 필요  | FcmNotificationSender만
  |
  | 코드 중복   | 높음              | 없음                     |
  | 확장성     | 낮음 (매번 type 추가) | 높음 (자동 추가)
   |
  | 유지보수    | 어려움 (여러 곳 수정)   | 쉬움 (한 곳만 수정)
       |

  질문 혹은 공유 사항 (Optional)

  💡 기술적 세부사항

  Kotlin Map의 + 연산자:
  val map1 = mapOf("a" to 1, "b" to 2)
  val map2 = mapOf("b" to 3, "c" to 4)
  val result = map1 + map2
  // 결과: {"a": 1, "b": 3, "c": 4}
  // 오른쪽 맵(map2)의 "b"가 왼쪽 맵(map1)의 "b"를 덮어씀

  이를 활용하여:
  val defaultData = mapOf("type" to "NOTICE")
  val userData = mapOf("type" to "CHAT", "chatRoomId" to "123")
  val result = defaultData + userData
  // 결과: {"type": "CHAT", "chatRoomId": "123"}

  ⚠️ 주의사항

  - 기본값은 항상 NOTICE로 설정됨
  - 명시적으로 다른 타입이 필요한 경우 data에 포함하여 덮어쓰기
  - 모든 FCM 알림에 자동 적용 (단일/배치 모두)

  🎯 향후 개선 가능 사항

  각 서비스 코드에서 불필요하게 명시된 type 제거 가능 (선택 사항):
  // 제거 가능
  data = mapOf("type" to NotificationDataType.NOTICE.value)

  // 또는 완전히 제거
  // data 전달 안 함
