### PR TITLE
[bug] 재심사 시 코드/얼굴 이미지만 제출하고 앱을 종료할 경우 히든프로필부터 시작하게 되는 문제 수정

### DIFF
--- a/src/main/kotlin/codel/member/business/ProfileReviewService.kt
+++ b/src/main/kotlin/codel/member/business/ProfileReviewService.kt
@@ -226,7 +226,7 @@ class ProfileReviewService(
 
         // 변경이 있었으면 재심사(정책에 맞게 조정)
         if (changed) {
-            findMember.memberStatus = MemberStatus.HIDDEN_COMPLETED
+//            findMember.memberStatus = MemberStatus.HIDDEN_COMPLETED
             messages += "심사가 다시 진행됩니다"
         } else {
             messages += "변경된 이미지가 없습니다"

--- a/src/main/kotlin/codel/member/business/SignupService.kt
+++ b/src/main/kotlin/codel/member/business/SignupService.kt
@@ -203,7 +203,7 @@ class SignupService(
         profile.updateHiddenProfileImages(faceImage.urls)
 
         // Hidden Profile 완료 상태로 변경
-        findMember.completeHiddenProfile()
+//        findMember.completeHiddenProfile()
 
         memberJpaRepository.save(findMember)
     }


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

[bug] 재심사 시 코드/얼굴 이미지만 제출하고 앱을 종료할 경우 히든프로필부터 시작하게 되는 문제 수정

## 이슈 ID는 무엇인가요?

- closes #362 

## 설명

<!-- 수정 사항, 참조 사항 등 자세한 내용을 적어주세요 (스크린샷이 포함되면 기능 이해해 많은 도움이 됩니다.) -->

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
